### PR TITLE
add issuer rbac and webhook implementation

### DIFF
--- a/charts/odh-observability/templates/rbac.yaml
+++ b/charts/odh-observability/templates/rbac.yaml
@@ -39,9 +39,13 @@ rules:
   - apiGroups: ["perses.dev"]
     resources: ["perses", "persesdatasources", "persesdashboards"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-  # Admission policies (built-in K8s resource, not a CRD)
+  # Admission policies and webhook configuration
   - apiGroups: ["admissionregistration.k8s.io"]
-    resources: ["validatingadmissionpolicies", "validatingadmissionpolicybindings"]
+    resources: ["validatingadmissionpolicies", "validatingadmissionpolicybindings", "mutatingwebhookconfigurations"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # cert-manager (for webhook TLS provisioning)
+  - apiGroups: ["cert-manager.io"]
+    resources: ["issuers", "certificates"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   # RBAC
   - apiGroups: ["rbac.authorization.k8s.io"]

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -71,7 +71,7 @@ func main() {
 	flag.StringVar(&probeAddr, "health-probe-bind-address", ":8081", "The address the probe endpoint binds to.")
 	flag.BoolVar(&leaderElect, "leader-elect", false, "Enable leader election for controller manager.")
 	flag.StringVar(&webhookCertDir, "webhook-cert-dir", "/tmp/k8s-webhook-server/serving-certs", "Directory containing the webhook TLS certificate.")
-	flag.BoolVar(&enableWebhook, "enable-webhook", true, "Enable the mutating admission webhook.")
+	flag.BoolVar(&enableWebhook, "enable-webhook", false, "Enable the mutating admission webhook (requires TLS certs to be mounted).")
 
 	opts := zap.Options{Development: true}
 	opts.BindFlags(flag.CommandLine)
@@ -82,7 +82,7 @@ func main() {
 
 	cfg := ctrl.GetConfigOrDie()
 
-	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
+	mgrOpts := ctrl.Options{
 		Scheme: scheme,
 		Metrics: metricsserver.Options{
 			BindAddress: metricsAddr,
@@ -90,11 +90,16 @@ func main() {
 		HealthProbeBindAddress: probeAddr,
 		LeaderElection:         leaderElect,
 		LeaderElectionID:       "odh-observability-leader",
-		WebhookServer: webhook.NewServer(webhook.Options{
+	}
+
+	if enableWebhook {
+		mgrOpts.WebhookServer = webhook.NewServer(webhook.Options{
 			Port:    9443,
 			CertDir: webhookCertDir,
-		}),
-	})
+		})
+	}
+
+	mgr, err := ctrl.NewManager(cfg, mgrOpts)
 	if err != nil {
 		setupLog.Error(err, "Unable to create manager")
 		os.Exit(1)

--- a/internal/controller/actions.go
+++ b/internal/controller/actions.go
@@ -20,10 +20,15 @@ import (
 	"context"
 	"embed"
 	"fmt"
+	"os"
 
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
 
 	v1alpha1 "github.com/opendatahub-io/odh-observability/api/v1alpha1"
 	"github.com/opendatahub-io/odh-observability/internal/controller/conditions"
@@ -452,6 +457,11 @@ func deployNodeMetricsEndpoint(
 // Issuer+Certificate, and MutatingWebhookConfiguration. These resources are
 // managed by the module operator (not the platform chart) so the operator
 // controls their lifecycle alongside its own reconciliation.
+//
+// After creating the cert-manager resources, it checks whether the TLS secret
+// has been provisioned. Once the secret is ready, it patches the operator's
+// own Deployment to enable the webhook server (adds volume mount, port, and
+// --enable-webhook=true). The rolling restart makes the webhook live.
 func deployWebhookInfrastructure(
 	ctx context.Context,
 	c client.Client,
@@ -459,6 +469,8 @@ func deployWebhookInfrastructure(
 	cm *conditions.ConditionsManager,
 	sources *[]rendertemplate.TemplateSource,
 ) error {
+	log := logf.FromContext(ctx)
+
 	issuerExists, err := hasCRD(ctx, c, gvk.CertManagerIssuer)
 	if err != nil {
 		return fmt.Errorf("checking Issuer CRD: %w", err)
@@ -471,12 +483,105 @@ func deployWebhookInfrastructure(
 		return nil
 	}
 
-	cm.MarkTrue(conditions.ConditionWebhookAvailable)
-
 	*sources = append(*sources,
 		src(WebhookServiceTemplate),
 		src(WebhookCertManagerTemplate),
 		src(WebhookConfigurationTemplate),
 	)
+
+	operatorName := getEnvOrDefault("OPERATOR_NAME", "odh-observability")
+	operatorNamespace := os.Getenv("POD_NAMESPACE")
+	secretName := operatorName + "-webhook-cert"
+
+	secret := &corev1.Secret{}
+	err = c.Get(ctx, types.NamespacedName{Name: secretName, Namespace: operatorNamespace}, secret)
+	if err != nil {
+		if k8serr.IsNotFound(err) {
+			log.Info("webhook TLS secret not yet provisioned by cert-manager, waiting", "secret", secretName)
+			cm.MarkFalse(conditions.ConditionWebhookAvailable,
+				"TLSSecretPending",
+				fmt.Sprintf("Waiting for cert-manager to provision TLS secret %s/%s", operatorNamespace, secretName))
+			return nil
+		}
+		return fmt.Errorf("checking webhook TLS secret: %w", err)
+	}
+
+	if err := ensureWebhookEnabled(ctx, c, operatorName, operatorNamespace, secretName); err != nil {
+		log.Error(err, "Failed to enable webhook on operator Deployment")
+		cm.MarkFalse(conditions.ConditionWebhookAvailable,
+			"DeploymentPatchFailed",
+			fmt.Sprintf("Failed to patch operator Deployment: %v", err))
+		return nil
+	}
+
+	cm.MarkTrue(conditions.ConditionWebhookAvailable)
 	return nil
+}
+
+const (
+	webhookArgEnabled  = "--enable-webhook=true"
+	webhookVolumeName  = "webhook-certs"
+	webhookCertMountPath = "/tmp/k8s-webhook-server/serving-certs"
+	webhookPort        = int32(9443)
+)
+
+// ensureWebhookEnabled patches the operator Deployment to enable the webhook
+// server if it isn't already configured. It adds the --enable-webhook=true
+// argument, the TLS secret volume mount, and the webhook port.
+func ensureWebhookEnabled(
+	ctx context.Context,
+	c client.Client,
+	operatorName, operatorNamespace, secretName string,
+) error {
+	dep := &appsv1.Deployment{}
+	if err := c.Get(ctx, types.NamespacedName{Name: operatorName, Namespace: operatorNamespace}, dep); err != nil {
+		return fmt.Errorf("getting operator Deployment: %w", err)
+	}
+
+	if len(dep.Spec.Template.Spec.Containers) == 0 {
+		return fmt.Errorf("operator Deployment has no containers")
+	}
+
+	container := &dep.Spec.Template.Spec.Containers[0]
+
+	hasWebhookArg := false
+	for _, arg := range container.Args {
+		if arg == webhookArgEnabled {
+			hasWebhookArg = true
+			break
+		}
+	}
+
+	if hasWebhookArg {
+		return nil
+	}
+
+	log := logf.FromContext(ctx)
+	log.Info("Patching operator Deployment to enable webhook",
+		"deployment", operatorName, "namespace", operatorNamespace)
+
+	container.Args = append(container.Args, webhookArgEnabled)
+
+	container.Ports = append(container.Ports, corev1.ContainerPort{
+		Name:          "webhook",
+		ContainerPort: webhookPort,
+		Protocol:      corev1.ProtocolTCP,
+	})
+
+	container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
+		Name:      webhookVolumeName,
+		MountPath: webhookCertMountPath,
+		ReadOnly:  true,
+	})
+
+	dep.Spec.Template.Spec.Volumes = append(dep.Spec.Template.Spec.Volumes, corev1.Volume{
+		Name: webhookVolumeName,
+		VolumeSource: corev1.VolumeSource{
+			Secret: &corev1.SecretVolumeSource{
+				SecretName: secretName,
+			},
+		},
+	})
+
+	return c.Update(ctx, dep)
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- The platofrm operator should not create the webhook resources, the module should.
- The module should start -> create the required resources -> set it's own configuration so that the module is managing all its own resources.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced webhook infrastructure with automatic TLS certificate provisioning and comprehensive lifecycle management for secure deployments.

* **Chores**
  * Expanded RBAC security permissions for admission control policies, validating webhook configurations, and certificate management operations.
  * Configuration change: webhook server now defaults to a disabled state for enhanced security posture; can be optionally enabled when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->