### PR TITLE
Fix/gc and webhook bugs

### DIFF
--- a/charts/odh-observability/values.yaml
+++ b/charts/odh-observability/values.yaml
@@ -29,6 +29,15 @@ nodeSelector: {}
 tolerations: []
 affinity: {}
 
+webhook:
+  enabled: true
+  port: 9443
+
+certManager:
+  enabled: true
+  certificateName: odh-observability-webhook-cert
+  secretName: odh-observability-webhook-tls
+
 # Extra environment variables injected into the controller container.
 # Use for RELATED_IMAGE_* overrides.
 env: []

--- a/internal/controller/actions.go
+++ b/internal/controller/actions.go
@@ -506,6 +506,14 @@ func deployWebhookInfrastructure(
 		return fmt.Errorf("checking webhook TLS secret: %w", err)
 	}
 
+	if len(secret.Data["tls.crt"]) == 0 || len(secret.Data["tls.key"]) == 0 {
+		log.Info("webhook TLS secret exists but certificate data not yet populated", "secret", secretName)
+		cm.MarkFalse(conditions.ConditionWebhookAvailable,
+			"TLSSecretPending",
+			"TLS secret exists but certificate data not yet populated by cert-manager")
+		return nil
+	}
+
 	if err := ensureWebhookEnabled(ctx, c, operatorName, operatorNamespace, secretName); err != nil {
 		log.Error(err, "Failed to enable webhook on operator Deployment")
 		cm.MarkFalse(conditions.ConditionWebhookAvailable,
@@ -552,29 +560,12 @@ func ensureWebhookEnabled(
 		}
 	}
 
-	if hasWebhookArg {
-		return nil
-	}
-
-	log := logf.FromContext(ctx)
-	log.Info("Patching operator Deployment to enable webhook",
-		"deployment", operatorName, "namespace", operatorNamespace)
-
-	container.Args = append(container.Args, webhookArgEnabled)
-
 	hasPort := false
 	for _, p := range container.Ports {
 		if p.Name == "webhook" {
 			hasPort = true
 			break
 		}
-	}
-	if !hasPort {
-		container.Ports = append(container.Ports, corev1.ContainerPort{
-			Name:          "webhook",
-			ContainerPort: webhookPort,
-			Protocol:      corev1.ProtocolTCP,
-		})
 	}
 
 	hasMount := false
@@ -584,13 +575,6 @@ func ensureWebhookEnabled(
 			break
 		}
 	}
-	if !hasMount {
-		container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
-			Name:      webhookVolumeName,
-			MountPath: webhookCertMountPath,
-			ReadOnly:  true,
-		})
-	}
 
 	hasVolume := false
 	for _, v := range dep.Spec.Template.Spec.Volumes {
@@ -599,6 +583,35 @@ func ensureWebhookEnabled(
 			break
 		}
 	}
+
+	if hasWebhookArg && hasPort && hasMount && hasVolume {
+		return nil
+	}
+
+	log := logf.FromContext(ctx)
+	log.Info("Patching operator Deployment to enable webhook",
+		"deployment", operatorName, "namespace", operatorNamespace)
+
+	if !hasWebhookArg {
+		container.Args = append(container.Args, webhookArgEnabled)
+	}
+
+	if !hasPort {
+		container.Ports = append(container.Ports, corev1.ContainerPort{
+			Name:          "webhook",
+			ContainerPort: webhookPort,
+			Protocol:      corev1.ProtocolTCP,
+		})
+	}
+
+	if !hasMount {
+		container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
+			Name:      webhookVolumeName,
+			MountPath: webhookCertMountPath,
+			ReadOnly:  true,
+		})
+	}
+
 	if !hasVolume {
 		dep.Spec.Template.Spec.Volumes = append(dep.Spec.Template.Spec.Volumes, corev1.Volume{
 			Name: webhookVolumeName,

--- a/internal/controller/actions.go
+++ b/internal/controller/actions.go
@@ -562,26 +562,53 @@ func ensureWebhookEnabled(
 
 	container.Args = append(container.Args, webhookArgEnabled)
 
-	container.Ports = append(container.Ports, corev1.ContainerPort{
-		Name:          "webhook",
-		ContainerPort: webhookPort,
-		Protocol:      corev1.ProtocolTCP,
-	})
+	hasPort := false
+	for _, p := range container.Ports {
+		if p.Name == "webhook" {
+			hasPort = true
+			break
+		}
+	}
+	if !hasPort {
+		container.Ports = append(container.Ports, corev1.ContainerPort{
+			Name:          "webhook",
+			ContainerPort: webhookPort,
+			Protocol:      corev1.ProtocolTCP,
+		})
+	}
 
-	container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
-		Name:      webhookVolumeName,
-		MountPath: webhookCertMountPath,
-		ReadOnly:  true,
-	})
+	hasMount := false
+	for _, m := range container.VolumeMounts {
+		if m.Name == webhookVolumeName {
+			hasMount = true
+			break
+		}
+	}
+	if !hasMount {
+		container.VolumeMounts = append(container.VolumeMounts, corev1.VolumeMount{
+			Name:      webhookVolumeName,
+			MountPath: webhookCertMountPath,
+			ReadOnly:  true,
+		})
+	}
 
-	dep.Spec.Template.Spec.Volumes = append(dep.Spec.Template.Spec.Volumes, corev1.Volume{
-		Name: webhookVolumeName,
-		VolumeSource: corev1.VolumeSource{
-			Secret: &corev1.SecretVolumeSource{
-				SecretName: secretName,
+	hasVolume := false
+	for _, v := range dep.Spec.Template.Spec.Volumes {
+		if v.Name == webhookVolumeName {
+			hasVolume = true
+			break
+		}
+	}
+	if !hasVolume {
+		dep.Spec.Template.Spec.Volumes = append(dep.Spec.Template.Spec.Volumes, corev1.Volume{
+			Name: webhookVolumeName,
+			VolumeSource: corev1.VolumeSource{
+				Secret: &corev1.SecretVolumeSource{
+					SecretName: secretName,
+				},
 			},
-		},
-	})
+		})
+	}
 
 	return c.Update(ctx, dep)
 }

--- a/internal/controller/monitoring_reconciler.go
+++ b/internal/controller/monitoring_reconciler.go
@@ -231,6 +231,10 @@ type resourceKey struct {
 
 // collectGarbage deletes owned resources not in the desired set using API discovery.
 func (r *MonitoringReconciler) collectGarbage(ctx context.Context, monitoring *v1alpha1.Monitoring, desired []unstructured.Unstructured) error {
+	if monitoring.Spec.Namespace == "" {
+		return fmt.Errorf("monitoring.Spec.Namespace is empty, cannot safely perform garbage collection")
+	}
+
 	desiredSet := make(map[resourceKey]struct{}, len(desired))
 	for i := range desired {
 		obj := &desired[i]
@@ -268,6 +272,10 @@ func (r *MonitoringReconciler) collectGarbage(ctx context.Context, monitoring *v
 
 // deleteAllOwned removes all resources owned by this controller (used on Removed state).
 func (r *MonitoringReconciler) deleteAllOwned(ctx context.Context, monitoring *v1alpha1.Monitoring) error {
+	if monitoring.Spec.Namespace == "" {
+		return fmt.Errorf("monitoring.Spec.Namespace is empty, cannot safely delete owned resources")
+	}
+
 	collector := gc.New(
 		gc.WithOnlyCollectOwned(false),
 		gc.WithLabel(odhLabels.PlatformPartOf, "monitoring"),

--- a/internal/controller/monitoring_reconciler.go
+++ b/internal/controller/monitoring_reconciler.go
@@ -244,6 +244,7 @@ func (r *MonitoringReconciler) collectGarbage(ctx context.Context, monitoring *v
 	collector := gc.New(
 		gc.WithOnlyCollectOwned(false),
 		gc.WithLabel(odhLabels.PlatformPartOf, "monitoring"),
+		gc.InNamespace(monitoring.Spec.Namespace),
 		gc.WithObjectPredicate(func(_ gc.RunParams, obj unstructured.Unstructured) (bool, error) {
 			k := resourceKey{
 				gvk:       obj.GroupVersionKind(),
@@ -270,6 +271,7 @@ func (r *MonitoringReconciler) deleteAllOwned(ctx context.Context, monitoring *v
 	collector := gc.New(
 		gc.WithOnlyCollectOwned(false),
 		gc.WithLabel(odhLabels.PlatformPartOf, "monitoring"),
+		gc.InNamespace(monitoring.Spec.Namespace),
 		gc.WithObjectPredicate(func(_ gc.RunParams, _ unstructured.Unstructured) (bool, error) {
 			return true, nil
 		}),


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Fixes three bugs discovered during integration testing of the ODH operator module handler on a live OpenShift cluster.

  - GC completely broken: `collectGarbage` and `deleteAllOwned` don't pass a namespace to the GC collector. The Monitoring CR is cluster-scoped, so SelfSubjectRulesReview gets an empty namespace and fails every reconcile. Stale resources are never cleaned up.
  - Webhook self-patching creates duplicates: `ensureWebhookEnabled` always appends the webhook port, volume mount, and volume without checking if they already exist. After the ODH operator resets the deployment args via SSA, the function tries to re-add them, and the API server rejects the update. This puts `WebhookAvailable` into a permanent `DeploymentPatchFailed` state.
  - Chart rendering fails with strict mode: Templates reference `.Values.webhook` and `.Values.certManager` but values.yaml has no defaults. Works with plain Helm but fails with the ODH operator's strict renderer (`missingkey=error`).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
All three fixes were validated end-to-end on a live OpenShift cluster running the ODH operator module handler branch.

  - Chart renders successfully through the ODH operator's strict Helm renderer
  - GC deletes stale resources when traces config is removed from the DSCI (no more
  `SelfSubjectRulesReview` errors in logs)
  - Webhook patching succeeds after ODH operator resets deployment via SSA, `WebhookAvailable=True` with no duplicate port/volume errors
  - Scaling ODH operator to 0, changing DSCI, scaling back up leads to correct convergence

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added webhook and certificate manager configuration options

* **Bug Fixes**
  * Fixed webhook enablement logic to prevent duplicate entries
  * Improved resource cleanup to properly respect namespace boundaries

<!-- end of auto-generated comment: release notes by coderabbit.ai -->