### PR TITLE
Fix/operator best practices - finalizer, error surfacing, webhook patching

### DIFF
--- a/charts/odh-observability/values.yaml
+++ b/charts/odh-observability/values.yaml
@@ -36,7 +36,7 @@ webhook:
 certManager:
   enabled: true
   certificateName: odh-observability-webhook-cert
-  secretName: odh-observability-webhook-tls
+  secretName: odh-observability-webhook-cert
 
 # Extra environment variables injected into the controller container.
 # Use for RELATED_IMAGE_* overrides.

--- a/internal/controller/actions.go
+++ b/internal/controller/actions.go
@@ -527,15 +527,16 @@ func deployWebhookInfrastructure(
 }
 
 const (
-	webhookArgEnabled  = "--enable-webhook=true"
-	webhookVolumeName  = "webhook-certs"
+	webhookArgEnabled    = "--enable-webhook=true"
+	webhookVolumeName    = "webhook-certs"
 	webhookCertMountPath = "/tmp/k8s-webhook-server/serving-certs"
-	webhookPort        = int32(9443)
+	webhookPort          = int32(9443)
 )
 
 // ensureWebhookEnabled patches the operator Deployment to enable the webhook
-// server if it isn't already configured. It adds the --enable-webhook=true
-// argument, the TLS secret volume mount, and the webhook port.
+// server if it isn't already configured. It uses a strategic merge patch to
+// add the webhook arg, port, volume mount, and volume without clobbering
+// fields managed by Helm or other controllers.
 func ensureWebhookEnabled(
 	ctx context.Context,
 	c client.Client,
@@ -592,6 +593,8 @@ func ensureWebhookEnabled(
 	log.Info("Patching operator Deployment to enable webhook",
 		"deployment", operatorName, "namespace", operatorNamespace)
 
+	patch := client.StrategicMergeFrom(dep.DeepCopy())
+
 	if !hasWebhookArg {
 		container.Args = append(container.Args, webhookArgEnabled)
 	}
@@ -623,5 +626,5 @@ func ensureWebhookEnabled(
 		})
 	}
 
-	return c.Update(ctx, dep)
+	return c.Patch(ctx, dep, patch)
 }

--- a/internal/controller/conditions/conditions.go
+++ b/internal/controller/conditions/conditions.go
@@ -81,22 +81,22 @@ const (
 	TracesNotConfiguredMessage   = "Traces not configured in Monitoring CR"
 	AlertingNotConfiguredMessage = "Alerting not configured in Monitoring CR"
 
-	TempoOperatorMissingMessage                 = "Tempo operator must be installed for traces configuration"
-	COOMissingMessage                           = "ClusterObservability operator must be installed for metrics configuration"
+	TempoOperatorMissingMessage                  = "Tempo operator must be installed for traces configuration"
+	COOMissingMessage                            = "ClusterObservability operator must be installed for metrics configuration"
 	OpenTelemetryCollectorOperatorMissingMessage = "OpenTelemetryCollector operator must be installed for OpenTelemetry configuration"
 )
 
 // featureConditionTypes lists the feature-specific condition types that
 // participate in the Ready/Degraded aggregation.
 var featureConditionTypes = map[string]bool{
-	ConditionMonitoringStackAvailable:           true,
-	ConditionThanosQuerierAvailable:             true,
-	ConditionTempoAvailable:                     true,
-	ConditionInstrumentationAvailable:           true,
+	ConditionMonitoringStackAvailable:            true,
+	ConditionThanosQuerierAvailable:              true,
+	ConditionTempoAvailable:                      true,
+	ConditionInstrumentationAvailable:            true,
 	ConditionOpenTelemetryCollectorAvailable:     true,
-	ConditionAlertingAvailable:                  true,
-	ConditionPersesAvailable:                    true,
-	ConditionPersesTempoDataSourceAvailable:     true,
+	ConditionAlertingAvailable:                   true,
+	ConditionPersesAvailable:                     true,
+	ConditionPersesTempoDataSourceAvailable:      true,
 	ConditionPersesPrometheusDataSourceAvailable: true,
 	ConditionNodeMetricsEndpointAvailable:        true,
 	ConditionWebhookAvailable:                    true,

--- a/internal/controller/conditions/conditions_test.go
+++ b/internal/controller/conditions/conditions_test.go
@@ -28,8 +28,8 @@ type testAccessor struct {
 	conditions []platformcommon.Condition
 }
 
-func (a *testAccessor) GetConditions() []platformcommon.Condition     { return a.conditions }
-func (a *testAccessor) SetConditions(c []platformcommon.Condition)    { a.conditions = c }
+func (a *testAccessor) GetConditions() []platformcommon.Condition  { return a.conditions }
+func (a *testAccessor) SetConditions(c []platformcommon.Condition) { a.conditions = c }
 
 func newTestCM() (*ConditionsManager, *testAccessor) {
 	acc := &testAccessor{}

--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -125,26 +125,27 @@ const thanosQuerierRouteName = "data-science-thanos-querier-route"
 
 // syncStatusURL fetches the Thanos Querier route and updates monitoring.Status.URL.
 // When metrics are not configured the URL is cleared.
-func syncStatusURL(ctx context.Context, c client.Client, monitoring *v1alpha1.Monitoring) {
+func syncStatusURL(ctx context.Context, c client.Client, monitoring *v1alpha1.Monitoring) error {
 	if monitoring.Spec.Metrics == nil {
 		monitoring.Status.URL = ""
-		return
+		return nil
 	}
 
-	log := logf.FromContext(ctx).WithName("syncStatusURL")
 	route := &routev1.Route{}
 	if err := c.Get(ctx, client.ObjectKey{
 		Namespace: monitoring.Spec.Namespace,
 		Name:      thanosQuerierRouteName,
 	}, route); err != nil {
-		if !errors.IsNotFound(err) {
-			log.Error(err, "Failed to fetch Thanos Querier route for status URL")
-		}
 		monitoring.Status.URL = ""
-		return
+		if errors.IsNotFound(err) {
+			return nil
+		}
+		return fmt.Errorf("failed to fetch Thanos Querier route for status URL: %w", err)
 	}
 
 	if len(route.Status.Ingress) > 0 && route.Status.Ingress[0].Host != "" {
 		monitoring.Status.URL = "https://" + route.Status.Ingress[0].Host
 	}
+
+	return nil
 }

--- a/internal/controller/monitoring_reconciler.go
+++ b/internal/controller/monitoring_reconciler.go
@@ -106,8 +106,9 @@ func (r *MonitoringReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 				log.Error(err, "Failed to delete owned resources during finalizer cleanup")
 				return ctrl.Result{}, err
 			}
+			patch := client.MergeFrom(monitoring.DeepCopy())
 			controllerutil.RemoveFinalizer(monitoring, monitoringFinalizer)
-			if err := r.Update(ctx, monitoring); err != nil {
+			if err := r.Patch(ctx, monitoring, patch); err != nil {
 				return ctrl.Result{}, err
 			}
 		}
@@ -115,8 +116,9 @@ func (r *MonitoringReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 	}
 
 	if !controllerutil.ContainsFinalizer(monitoring, monitoringFinalizer) {
+		patch := client.MergeFrom(monitoring.DeepCopy())
 		controllerutil.AddFinalizer(monitoring, monitoringFinalizer)
-		if err := r.Update(ctx, monitoring); err != nil {
+		if err := r.Patch(ctx, monitoring, patch); err != nil {
 			return ctrl.Result{}, err
 		}
 	}

--- a/internal/controller/monitoring_reconciler.go
+++ b/internal/controller/monitoring_reconciler.go
@@ -38,6 +38,7 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/builder"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
@@ -53,6 +54,8 @@ import (
 	v1alpha1 "github.com/opendatahub-io/odh-observability/api/v1alpha1"
 	"github.com/opendatahub-io/odh-observability/internal/controller/conditions"
 )
+
+const monitoringFinalizer = "monitoring.opendatahub.io/cleanup"
 
 // MonitoringReconciler reconciles a Monitoring object.
 type MonitoringReconciler struct {
@@ -91,6 +94,31 @@ func (r *MonitoringReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 			return ctrl.Result{}, nil
 		}
 		return ctrl.Result{}, err
+	}
+
+	// Handle finalizer for cleanup on deletion. The ODH module handler's
+	// two-phase cleanup relies on the finalizer keeping the CR alive while
+	// deleteAllOwned runs.
+	if !monitoring.DeletionTimestamp.IsZero() {
+		if controllerutil.ContainsFinalizer(monitoring, monitoringFinalizer) {
+			log.Info("Monitoring CR is being deleted, cleaning up owned resources")
+			if err := r.deleteAllOwned(ctx, monitoring); err != nil {
+				log.Error(err, "Failed to delete owned resources during finalizer cleanup")
+				return ctrl.Result{}, err
+			}
+			controllerutil.RemoveFinalizer(monitoring, monitoringFinalizer)
+			if err := r.Update(ctx, monitoring); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+		return ctrl.Result{}, nil
+	}
+
+	if !controllerutil.ContainsFinalizer(monitoring, monitoringFinalizer) {
+		controllerutil.AddFinalizer(monitoring, monitoringFinalizer)
+		if err := r.Update(ctx, monitoring); err != nil {
+			return ctrl.Result{}, err
+		}
 	}
 
 	// Snapshot status for patch at end.
@@ -213,10 +241,15 @@ func (r *MonitoringReconciler) reconcile(ctx context.Context, monitoring *v1alph
 	// Sync Prometheus CA ConfigMap → Secret (workaround for COO-1270).
 	if err := syncPrometheusWebTLSCA(ctx, r.Client, monitoring); err != nil {
 		log.Error(err, "Failed to sync Prometheus web TLS CA")
+		cm.MarkFalse(conditions.ConditionMonitoringStackAvailable,
+			"PrometheusCAConfigSyncFailed",
+			fmt.Sprintf("Failed to sync Prometheus web TLS CA: %v", err))
 	}
 
 	// Populate status.url from the Thanos Querier route.
-	syncStatusURL(ctx, r.Client, monitoring)
+	if err := syncStatusURL(ctx, r.Client, monitoring); err != nil {
+		log.Error(err, "Failed to sync status URL")
+	}
 
 	cm.AggregateReady()
 	return ctrl.Result{}, nil


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
- Add finalizer (monitoring.opendatahub.io/cleanup) so CR deletion triggers deleteAllOwned before the CR is removed from etcd, required for the ODH module handler's two-phase cleanup pattern
- Surface syncPrometheusWebTLSCA errors in conditions (MonitoringStackAvailable=False) instead of only logging them 
- Change syncStatusURL to return errors instead of swallowing them
- Replace c.Update() with client.StrategicMergeFrom patch in ensureWebhookEnabled to avoid clobbering fields managed by Helm or other controllers
- Fix certManager.secretName in values.yaml to match the actual secret name used by the cert-manager Certificate template

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on a live cluster with the ODH operator PR.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling and reporting for monitoring stack availability and status synchronization
  * Enhanced resource cleanup during monitoring deletion using finalizer logic

* **Chores**
  * Updated webhook TLS certificate reference in observability configuration
  * Minor formatting and alignment cleanups in internal code/tests
<!-- end of auto-generated comment: release notes by coderabbit.ai -->