### PR TITLE
fix: align Dockerfile with ODH component conventions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,14 @@
-# Build the manager binary
-# Build context must be the parent directory (RHOAI-dev/) so that
-# odh-platform-utilities is accessible alongside odh-observability.
-# Use: docker build -f odh-observability/Dockerfile -t <img> <parent-dir>
-# Or:  make docker-build (Makefile sets the context to ..)
-FROM golang:1.25 AS builder
+ARG GOLANG_VERSION=1.25
 
+ARG BUILDPLATFORM
+ARG TARGETPLATFORM
+
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/go-toolset:$GOLANG_VERSION AS builder
+ARG CGO_ENABLED=1
+ARG GOEXPERIMENT=strictfipsruntime
 ARG TARGETOS
 ARG TARGETARCH
-
+USER root
 WORKDIR /workspace
 COPY odh-observability/go.mod go.mod
 COPY odh-observability/go.sum go.sum
@@ -21,12 +22,11 @@ COPY odh-observability/cmd/main.go cmd/main.go
 COPY odh-observability/api/ api/
 COPY odh-observability/internal/ internal/
 
-RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o manager cmd/main.go
+RUN CGO_ENABLED=${CGO_ENABLED} GOEXPERIMENT=${GOEXPERIMENT} GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -trimpath -ldflags="-s -w" -o manager cmd/main.go
 
-# Use distroless as minimal base image to package the manager binary
-FROM gcr.io/distroless/static:nonroot
+FROM --platform=$TARGETPLATFORM registry.access.redhat.com/ubi9/ubi-minimal:latest
 WORKDIR /
 COPY --from=builder /workspace/manager .
-USER 65532:65532
+USER 1001
 
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
Aligns dockerfile with how the ODH operator and other components have them configured.

## Description
<!--- Describe your changes in detail -->
- Switch builder image from `golang:1.25` to `ubi9/go-toolset` (Red Hat UBI)
- Switch runtime image from `gcr.io/distroless/static:nonroot` to `ubi9/ubi-minimal`
- Enable FIPS-compliant crypto via `GOEXPERIMENT=strictfipsruntime`
- Add `-trimpath` and `-ldflags="-s -w"` for reproducible, stripped builds
- Use `USER 1001` per OpenShift convention

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Testing by building the image and deploying on a live cluster with the ODH module handler.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated container runtime environment with enhanced security configurations and compliance support.
  * Optimized binary build and deployment package with reduced footprint.
  * Updated container execution parameters for improved system compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->