### PR TITLE
fix: use odh-stable as image for charts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 # Image URL to use all building/pushing image targets
-IMG ?= quay.io/opendatahub/odh-observability:latest
+IMG ?= quay.io/opendatahub/odh-observability:odh-stable
 PLATFORM ?= linux/amd64
 CGO_ENABLED ?= 1
 

--- a/charts/odh-observability/values.yaml
+++ b/charts/odh-observability/values.yaml
@@ -6,7 +6,7 @@ operatorNamespace: opendatahub-operator-system
 image:
   repository: quay.io/opendatahub/odh-observability
   tag: odh-stable
-  pullPolicy: IfNotPresent
+  pullPolicy: Always
 
 replicaCount: 1
 

--- a/charts/odh-observability/values.yaml
+++ b/charts/odh-observability/values.yaml
@@ -5,7 +5,7 @@ operatorNamespace: opendatahub-operator-system
 
 image:
   repository: quay.io/opendatahub/odh-observability
-  tag: latest
+  tag: odh-stable
   pullPolicy: IfNotPresent
 
 replicaCount: 1


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The konflux builds push to odh-stable on a merge to main, this aligns the values.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [ ] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default image tags for observability components to use stable versions instead of latest builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->