### PR TITLE
add fixes surfaced in e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,10 @@ unit-test: ## Run unit tests (no codegen prerequisites).
 test-verbose: ## Run unit tests with verbose output.
 	go test -v ./...
 
+.PHONY: e2e-test
+e2e-test: ## Run e2e tests against a cluster (requires KUBECONFIG).
+	go test ./tests/e2e/ -v -timeout 120m -count=1 $(E2E_TEST_FLAGS)
+
 ##@ Build
 
 .PHONY: build
@@ -59,7 +63,10 @@ build: manifests generate fmt vet ## Build manager binary.
 	go build -o bin/manager cmd/main.go
 
 .PHONY: run
-run: manifests generate fmt vet ## Run a controller from your host.
+run: manifests generate fmt vet ## Run controller locally (requires POD_NAMESPACE, e.g. POD_NAMESPACE=opendatahub make run).
+ifndef POD_NAMESPACE
+	$(error POD_NAMESPACE is not set. Usage: POD_NAMESPACE=opendatahub make run)
+endif
 	go run ./cmd/main.go
 
 .PHONY: docker-build
@@ -75,26 +82,21 @@ image: docker-build docker-push ## Build and push image with the manager.
 
 ##@ Deployment
 
-ifndef ignore-not-found
-  ignore-not-found = false
-endif
-
-.PHONY: install
-install: manifests kustomize ## Install CRDs into the K8s cluster specified in ~/.kube/config.
-	$(KUSTOMIZE) build config/crd | kubectl apply -f -
-
-.PHONY: uninstall
-uninstall: manifests kustomize ## Uninstall CRDs from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
-	$(KUSTOMIZE) build config/crd | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
+HELM_RELEASE ?= odh-observability
+HELM_CHART   ?= charts/odh-observability
+NAMESPACE    ?= opendatahub
 
 .PHONY: deploy
-deploy: manifests kustomize ## Deploy controller to the K8s cluster specified in ~/.kube/config.
-	cd config/manager && $(KUSTOMIZE) edit set image controller=${IMG}
-	$(KUSTOMIZE) build config/default | kubectl apply -f -
+deploy: manifests helm-update-crds ## Deploy operator to cluster via Helm chart.
+	helm upgrade --install $(HELM_RELEASE) $(HELM_CHART) \
+		-n $(NAMESPACE) --create-namespace \
+		--set operatorNamespace=$(NAMESPACE) \
+		--set image.repository=$(firstword $(subst :, ,$(IMG))) \
+		--set image.tag=$(lastword $(subst :, ,$(IMG)))
 
 .PHONY: undeploy
-undeploy: ## Undeploy controller from the K8s cluster specified in ~/.kube/config. Call with ignore-not-found=true to ignore resource not found errors during deletion.
-	$(KUSTOMIZE) build config/default | kubectl delete --ignore-not-found=$(ignore-not-found) -f -
+undeploy: ## Remove operator from cluster.
+	helm uninstall $(HELM_RELEASE) -n $(NAMESPACE) --ignore-not-found
 
 .PHONY: helm-update-crds
 helm-update-crds: manifests ## Copy generated CRDs into the Helm chart crds/ directory.
@@ -116,14 +118,8 @@ $(LOCALBIN):
 	mkdir -p $(LOCALBIN)
 
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
-KUSTOMIZE ?= $(LOCALBIN)/kustomize
 
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.
 $(CONTROLLER_GEN): $(LOCALBIN)
 	test -s $(LOCALBIN)/controller-gen || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-tools/cmd/controller-gen@latest
-
-.PHONY: kustomize
-kustomize: $(KUSTOMIZE) ## Download kustomize locally if necessary.
-$(KUSTOMIZE): $(LOCALBIN)
-	test -s $(LOCALBIN)/kustomize || GOBIN=$(LOCALBIN) go install sigs.k8s.io/kustomize/kustomize/v5@latest

--- a/charts/odh-observability/values.yaml
+++ b/charts/odh-observability/values.yaml
@@ -42,4 +42,4 @@ certManager:
 # Use for RELATED_IMAGE_* overrides.
 env: []
 # - name: RELATED_IMAGE_PERSES_IMAGE
-#   value: "registry.redhat.io/cluster-observability-operator/perses-rhel9:1.3.1"
+#   value: "registry.redhat.io/cluster-observability-operator/perses-rhel9:1.5.0-1781116652"

--- a/internal/controller/actions.go
+++ b/internal/controller/actions.go
@@ -527,10 +527,10 @@ func deployWebhookInfrastructure(
 }
 
 const (
-	webhookArgEnabled  = "--enable-webhook=true"
-	webhookVolumeName  = "webhook-certs"
+	webhookArgEnabled    = "--enable-webhook=true"
+	webhookVolumeName    = "webhook-certs"
 	webhookCertMountPath = "/tmp/k8s-webhook-server/serving-certs"
-	webhookPort        = int32(9443)
+	webhookPort          = int32(9443)
 )
 
 // ensureWebhookEnabled patches the operator Deployment to enable the webhook

--- a/internal/controller/conditions/conditions.go
+++ b/internal/controller/conditions/conditions.go
@@ -81,22 +81,22 @@ const (
 	TracesNotConfiguredMessage   = "Traces not configured in Monitoring CR"
 	AlertingNotConfiguredMessage = "Alerting not configured in Monitoring CR"
 
-	TempoOperatorMissingMessage                 = "Tempo operator must be installed for traces configuration"
-	COOMissingMessage                           = "ClusterObservability operator must be installed for metrics configuration"
+	TempoOperatorMissingMessage                  = "Tempo operator must be installed for traces configuration"
+	COOMissingMessage                            = "ClusterObservability operator must be installed for metrics configuration"
 	OpenTelemetryCollectorOperatorMissingMessage = "OpenTelemetryCollector operator must be installed for OpenTelemetry configuration"
 )
 
 // featureConditionTypes lists the feature-specific condition types that
 // participate in the Ready/Degraded aggregation.
 var featureConditionTypes = map[string]bool{
-	ConditionMonitoringStackAvailable:           true,
-	ConditionThanosQuerierAvailable:             true,
-	ConditionTempoAvailable:                     true,
-	ConditionInstrumentationAvailable:           true,
+	ConditionMonitoringStackAvailable:            true,
+	ConditionThanosQuerierAvailable:              true,
+	ConditionTempoAvailable:                      true,
+	ConditionInstrumentationAvailable:            true,
 	ConditionOpenTelemetryCollectorAvailable:     true,
-	ConditionAlertingAvailable:                  true,
-	ConditionPersesAvailable:                    true,
-	ConditionPersesTempoDataSourceAvailable:     true,
+	ConditionAlertingAvailable:                   true,
+	ConditionPersesAvailable:                     true,
+	ConditionPersesTempoDataSourceAvailable:      true,
 	ConditionPersesPrometheusDataSourceAvailable: true,
 	ConditionNodeMetricsEndpointAvailable:        true,
 	ConditionWebhookAvailable:                    true,

--- a/internal/controller/conditions/conditions_test.go
+++ b/internal/controller/conditions/conditions_test.go
@@ -28,8 +28,8 @@ type testAccessor struct {
 	conditions []platformcommon.Condition
 }
 
-func (a *testAccessor) GetConditions() []platformcommon.Condition     { return a.conditions }
-func (a *testAccessor) SetConditions(c []platformcommon.Condition)    { a.conditions = c }
+func (a *testAccessor) GetConditions() []platformcommon.Condition  { return a.conditions }
+func (a *testAccessor) SetConditions(c []platformcommon.Condition) { a.conditions = c }
 
 func newTestCM() (*ConditionsManager, *testAccessor) {
 	acc := &testAccessor{}

--- a/internal/controller/resources/perses-datasource-cluster-prometheus.tmpl.yaml
+++ b/internal/controller/resources/perses-datasource-cluster-prometheus.tmpl.yaml
@@ -39,6 +39,7 @@ spec:
       enable: true
       caCert:
         type: configmap
+        namespace: {{.Namespace}}
         name: prometheus-web-tls-ca
         certPath: service-ca.crt
   config:

--- a/internal/controller/resources/perses-tempo-datasource.tmpl.yaml
+++ b/internal/controller/resources/perses-tempo-datasource.tmpl.yaml
@@ -11,6 +11,7 @@ spec:
       enable: true
       caCert:
         type: configmap
+        namespace: {{.Namespace}}
         name: tempo-service-ca
         certPath: service-ca.crt
   config:

--- a/internal/controller/templatedata.go
+++ b/internal/controller/templatedata.go
@@ -357,11 +357,19 @@ func getEnvOrDefault(envVar, defaultVal string) string {
 	return defaultVal
 }
 
+// getPersesImage returns the Perses image from environment variable or default.
+// For RHOAI deployments, this is set via the CSV (via RHOAI-Build-Config/bundle/additional-images-patch.yaml).
+// For ODH deployments, this uses the default value below.
+//
+// This image version must stay compatible with the Cluster Observability Operator (COO) version
+// that we depend on. When upgrading COO, verify Perses image compatibility and update accordingly.
+// The current image is compatible with COO 1.5.0.
 func getPersesImage() string {
 	if image := os.Getenv("RELATED_IMAGE_PERSES_IMAGE"); image != "" {
 		return image
 	}
-	return "registry.redhat.io/cluster-observability-operator/perses-rhel9:1.3.1-1765876130"
+
+	return "registry.redhat.io/cluster-observability-operator/perses-rhel9:1.5.0-1781116652@sha256:27553fd6d4b4983475a0d9a4ccc7d7fa63b1bd4b48f0e5cb2d18963fe232cfd5"
 }
 
 // resolvePersesAPIVersion probes the cluster for the installed Perses CRD API version.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
1. PersesDatasource templates missing namespace in TLS caCert (reconcile blocker)

	Both perses-datasource-cluster-prometheus.tmpl.yaml and perses-tempo-datasource.tmpl.yaml were missing the namespace field in their caCert blocks. The Perses CRD requires namespace when type is configmap or secret. This caused every reconcile to fail with a validation error, which cascaded into:

	- prometheus-web-tls-ca Secret never being created (the syncPrometheusWebTLSCA function never ran)
	- Prometheus pods stuck in Init:0/1 (waiting on the missing secret volume mount)
	- Thanos Querier deployment stuck in a create/delete loop with a foregroundDeletion finalizer

	Fix: Added namespace: {{.Namespace}} to both templates, matching what the ODH operator already has.

2. Perses image incompatible with COO v1.5.0

	- 	getPersesImage() hardcoded perses-rhel9:1.3.1, which doesn't support the --web.tls-min-version and --web.tls-cipher-suites flags that COO v1.5.0 injects into the Perses StatefulSet. This caused CrashLoopBackOff with flag provided but not defined: -web.tls-min-version.

	Fix: Updated the default to perses-rhel9:1.5.0-1781116652@sha256:27553fd... — the same digest-pinned image bundled with COO v1.5.0, matching the ODH operator.

3. Broken Makefile deployment targets

	- make install, make deploy, and make undeploy all used kustomize with config/crd, config/default, and config/manager directories that don't exist. The actual deployment method is the Helm chart. Additionally, make run didn't warn about the required POD_NAMESPACE env var, which causes template rendering to produce null values.

	Fix: Replaced kustomize targets with Helm-based deploy/undeploy, added a POD_NAMESPACE guard on run, removed the kustomize tool target.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- Deploy operator built from this code
- Enable metrics
- Verify everything deploys correctly
## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added end-to-end testing capability via new test target.

* **Improvements**
  * Migrated deployment mechanism to Helm for enhanced operator management.
  * Updated Perses to version 1.5.0 for improved compatibility and features.
  * Enhanced datasource configuration with explicit namespace binding for TLS CA certificates.

* **Chores**
  * Code formatting and alignment refinements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->