### PR TITLE
feat: inject OPERATOR_VERSION from chart appVersion and log at startup

### DIFF
--- a/charts/odh-observability/templates/deployment.yaml
+++ b/charts/odh-observability/templates/deployment.yaml
@@ -36,6 +36,8 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: OPERATOR_VERSION
+              value: {{ .Chart.AppVersion | quote }}
             {{- with .Values.env }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -79,6 +79,7 @@ func main() {
 
 	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
 	setupLog := ctrl.Log.WithName("setup")
+	setupLog.Info("odh-observability", "version", os.Getenv("OPERATOR_VERSION"))
 
 	cfg := ctrl.GetConfigOrDie()
 

--- a/internal/controller/monitoring_reconciler.go
+++ b/internal/controller/monitoring_reconciler.go
@@ -55,10 +55,7 @@ import (
 	"github.com/opendatahub-io/odh-observability/internal/controller/conditions"
 )
 
-const (
-	monitoringFinalizer = "monitoring.opendatahub.io/cleanup"
-	platformType        = "OpenDataHub"
-)
+const monitoringFinalizer = "monitoring.opendatahub.io/cleanup"
 
 func operatorVersion() string {
 	return os.Getenv("OPERATOR_VERSION")
@@ -236,7 +233,7 @@ func (r *MonitoringReconciler) reconcile(ctx context.Context, monitoring *v1alph
 	if err := r.Deployer.Deploy(ctx, deploy.DeployInput{
 		Client:    r.Client,
 		Owner:     monitoring,
-		Release:   deploy.ReleaseInfo{Type: platformType, Version: operatorVersion()},
+		Release:   deploy.ReleaseInfo{Type: "OpenDataHub", Version: operatorVersion()},
 		Resources: desired,
 	}); err != nil {
 		return ctrl.Result{}, fmt.Errorf("applying resources: %w", err)
@@ -308,7 +305,7 @@ func (r *MonitoringReconciler) collectGarbage(ctx context.Context, monitoring *v
 		DiscoveryClient: r.DiscoveryClient,
 		Owner:           monitoring,
 		Version:         operatorVersion(),
-		PlatformType:    platformType,
+		PlatformType:    "OpenDataHub",
 	})
 }
 
@@ -333,7 +330,7 @@ func (r *MonitoringReconciler) deleteAllOwned(ctx context.Context, monitoring *v
 		DiscoveryClient: r.DiscoveryClient,
 		Owner:           monitoring,
 		Version:         operatorVersion(),
-		PlatformType:    platformType,
+		PlatformType:    "OpenDataHub",
 	})
 }
 

--- a/internal/controller/monitoring_reconciler.go
+++ b/internal/controller/monitoring_reconciler.go
@@ -55,7 +55,14 @@ import (
 	"github.com/opendatahub-io/odh-observability/internal/controller/conditions"
 )
 
-const monitoringFinalizer = "monitoring.opendatahub.io/cleanup"
+const (
+	monitoringFinalizer = "monitoring.opendatahub.io/cleanup"
+	platformType        = "OpenDataHub"
+)
+
+func operatorVersion() string {
+	return os.Getenv("OPERATOR_VERSION")
+}
 
 // MonitoringReconciler reconciles a Monitoring object.
 type MonitoringReconciler struct {
@@ -151,7 +158,7 @@ func (r *MonitoringReconciler) reconcile(ctx context.Context, monitoring *v1alph
 			Releases: []platformcommon.ComponentRelease{{
 				Name:    v1alpha1.MonitoringServiceName,
 				RepoURL: "https://github.com/opendatahub-io/odh-observability",
-				Version: os.Getenv("OPERATOR_VERSION"),
+				Version: operatorVersion(),
 			}},
 		})
 	}()
@@ -229,7 +236,7 @@ func (r *MonitoringReconciler) reconcile(ctx context.Context, monitoring *v1alph
 	if err := r.Deployer.Deploy(ctx, deploy.DeployInput{
 		Client:    r.Client,
 		Owner:     monitoring,
-		Release:   deploy.ReleaseInfo{Type: "OpenDataHub", Version: os.Getenv("OPERATOR_VERSION")},
+		Release:   deploy.ReleaseInfo{Type: platformType, Version: operatorVersion()},
 		Resources: desired,
 	}); err != nil {
 		return ctrl.Result{}, fmt.Errorf("applying resources: %w", err)
@@ -300,8 +307,8 @@ func (r *MonitoringReconciler) collectGarbage(ctx context.Context, monitoring *v
 		DynamicClient:   r.DynamicClient,
 		DiscoveryClient: r.DiscoveryClient,
 		Owner:           monitoring,
-		Version:         os.Getenv("OPERATOR_VERSION"),
-		PlatformType:    "OpenDataHub",
+		Version:         operatorVersion(),
+		PlatformType:    platformType,
 	})
 }
 
@@ -325,8 +332,8 @@ func (r *MonitoringReconciler) deleteAllOwned(ctx context.Context, monitoring *v
 		DynamicClient:   r.DynamicClient,
 		DiscoveryClient: r.DiscoveryClient,
 		Owner:           monitoring,
-		Version:         os.Getenv("OPERATOR_VERSION"),
-		PlatformType:    "OpenDataHub",
+		Version:         operatorVersion(),
+		PlatformType:    platformType,
 	})
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Adds version reporting to the operator so status.releases[].version and deploy/GC metadata are populated instead of empty strings.

Approach: Follows the ODH ecosystem pattern of runtime version detection via environment variables (no ldflags). The parent operator and other ODH components use the same pattern — version is injected at deployment time, not baked into the binary.

Changes:
  - Helm chart deployment template now injects OPERATOR_VERSION env var from Chart.appVersion, ensuring standalone Helm installs always report a version
  - Operator logs its version at startup
  - Reconciler consolidates 4 scattered os.Getenv("OPERATOR_VERSION") calls into an operatorVersion() helper and 3 "OpenDataHub" string literals into a platformType constant

Modularity compliance audit (no code changes needed — documenting status):
  - PlatformObject contract, conditions, finalizer, label-based ownership, RELATED_IMAGE_* env vars, singleton enforcement: all compliant
  - Platform ConfigMap consumption (odh-monitoring-config) and version handshake (status.releases[name="platform"]): not yet implemented, requires platform team coordination. Readiness checker skips the version check when empty, so not blocking.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

  - go test ./... — all tests pass except the pre-existing TestReconcile_NothingConfigured failure (fixed in PR #N, not yet merged to main)
  - make helm-lint — chart lints cleanly
  - make helm-template | grep OPERATOR_VERSION — env var renders with value "0.1.0" from Chart.appVersion
  - go build ./... — builds without errors

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work
