### PR TITLE
fix(monitoring): remove orphaned RELATED_IMAGE_CLI_IMAGE

### DIFF
--- a/internal/controller/templatedata.go
+++ b/internal/controller/templatedata.go
@@ -344,10 +344,6 @@ func addImageURLs(templateData map[string]any) {
 		"RELATED_IMAGE_OSE_PROM_LABEL_PROXY_IMAGE",
 		"quay.io/prometheuscommunity/prom-label-proxy:v0.12.1",
 	)
-	templateData["CLIImage"] = getEnvOrDefault(
-		"RELATED_IMAGE_CLI_IMAGE",
-		"quay.io/openshift/origin-cli:4.17",
-	)
 }
 
 func getEnvOrDefault(envVar, defaultVal string) string {

--- a/internal/controller/templatedata_extended_test.go
+++ b/internal/controller/templatedata_extended_test.go
@@ -520,7 +520,6 @@ func TestAddResourceData(t *testing.T) {
 func TestAddImageURLs_Defaults(t *testing.T) {
 	os.Unsetenv("RELATED_IMAGE_ODH_KUBE_RBAC_PROXY_IMAGE")
 	os.Unsetenv("RELATED_IMAGE_OSE_PROM_LABEL_PROXY_IMAGE")
-	os.Unsetenv("RELATED_IMAGE_CLI_IMAGE")
 
 	data := make(map[string]any)
 	addImageURLs(data)
@@ -531,15 +530,11 @@ func TestAddImageURLs_Defaults(t *testing.T) {
 	if data["PromLabelProxyImage"] == "" {
 		t.Error("PromLabelProxyImage should have a default")
 	}
-	if data["CLIImage"] == "" {
-		t.Error("CLIImage should have a default")
-	}
 }
 
 func TestAddImageURLs_OverriddenByEnv(t *testing.T) {
 	t.Setenv("RELATED_IMAGE_ODH_KUBE_RBAC_PROXY_IMAGE", "custom-proxy:latest")
 	t.Setenv("RELATED_IMAGE_OSE_PROM_LABEL_PROXY_IMAGE", "custom-prom-proxy:latest")
-	t.Setenv("RELATED_IMAGE_CLI_IMAGE", "custom-cli:latest")
 
 	data := make(map[string]any)
 	addImageURLs(data)
@@ -549,9 +544,6 @@ func TestAddImageURLs_OverriddenByEnv(t *testing.T) {
 	}
 	if data["PromLabelProxyImage"] != "custom-prom-proxy:latest" {
 		t.Errorf("PromLabelProxyImage: want custom-prom-proxy:latest, got %v", data["PromLabelProxyImage"])
-	}
-	if data["CLIImage"] != "custom-cli:latest" {
-		t.Errorf("CLIImage: want custom-cli:latest, got %v", data["CLIImage"])
 	}
 }
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
The template that consumed CLIImage (prometheus-web-tls-ca-secret-job.tmpl.yaml) was removed, and the operator already dropped this env var in opendatahub-io/opendatahub-operator#3801. No template references CLIImage, so the getEnvOrDefault call and its test assertions are dead code.
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
  - Grep for orphaned references — confirmed CLIImage / RELATED_IMAGE_CLI_IMAGE is not used in any template (.tmpl.yaml), Go source, or Helm chart outside the removed code. The variable was truly orphaned.
  - Unit tests — make unit-test passes. The two affected tests (TestAddImageURLs_Defaults, TestAddImageURLs_OverriddenByEnv) were updated to remove the CLIImage assertions and continue to verify the remaining
  image variables (KubeRbacProxyImage, PromLabelProxyImage).
## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the unused CLI image setting from generated template data.
  * Continued supporting default and environment-configured values for the KubeRBAC proxy and Prometheus label proxy images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->