### PR TITLE
fix(build): use multi-arch base image digests in Konflux Dockerfile

### DIFF
--- a/Dockerfiles/Dockerfile.konflux
+++ b/Dockerfiles/Dockerfile.konflux
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM registry.redhat.io/ubi9/go-toolset@sha256:2a913b5473089fb4dc4e71b6206192460b149ebd6d948bb818ee5e339d9af65d AS builder
+FROM registry.redhat.io/ubi9/go-toolset@sha256:5d26ff5606bd6590930e7cfc202b510e3fe2c7a7a1720860f444ab49c45128cb AS builder
 
 # These built-in args are defined in the global scope, and are not automatically accessible within build stages or RUN commands.
 # To expose these arguments inside the build stage, we need to redefine it without a value.
@@ -18,16 +18,11 @@ COPY internal/ internal/
 USER root
 RUN CGO_ENABLED=1 GOOS=${TARGETOS} GOARCH=${TARGETARCH} GOEXPERIMENT=strictfipsruntime go build -tags strictfipsruntime -a -trimpath -ldflags="-s -w" -o manager cmd/main.go
 
-FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:94234988db7ce0e451e2dd9a8c4dcf1abf6895278a1c2d8633316a3e61d82a8f
-
-RUN microdnf install -y shadow-utils && \
-    microdnf clean all && \
-    useradd odh-observability -m -u 1000
-RUN microdnf remove -y shadow-utils
+FROM registry.access.redhat.com/ubi9/ubi-minimal@sha256:dd334afa72444fa46238fcf9e6bd399245adf746378735348cf84b9dfdca38f1
 
 WORKDIR /
 COPY --from=builder /workspace/manager .
-USER 1000:1000
+USER 1001
 
 ENTRYPOINT ["/manager"]
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Use a multi-arch digest instead of a single arch for the konflux dockerfile and clean up user to match existing ODH/RHOAI patterns.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
verified the new sha's are multi-arch and have a manifest list instead of a single manifest
```

skopeo inspect --raw docker://registry.access.redhat.com/ubi9/ubi-minimal@sha256:dd334afa72444fa46238fcf9e6bd399245adf746378735348cf84b9dfdca38f1 | jq .mediaType
"application/vnd.docker.distribution.manifest.list.v2+json"

skopeo inspect --raw docker://registry.redhat.io/ubi9/go-toolset@sha256:5d26ff5606bd6590930e7cfc202b510e3fe2c7a7a1720860f444ab49c45128cb | jq .mediaType
"application/vnd.docker.distribution.manifest.list.v2+json"
```

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [ ] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the application’s container images.
  * Improved container runtime security by using a non-root user with a revised user ID.
  * Removed unnecessary runtime package installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->