### PR TITLE
Feat/ci workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,76 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run tests
+        run: make test
+
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Run golangci-lint
+        uses: golangci/golangci-lint-action@v7
+        with:
+          version: latest
+
+  helm-lint:
+    name: Helm Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Lint Helm chart
+        run: make helm-lint
+
+  generated:
+    name: Generated Code
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+
+      - name: Generate manifests and code
+        run: make manifests generate
+
+      - name: Sync CRDs to Helm chart
+        run: make helm-update-crds
+
+      - name: Check for uncommitted changes
+        run: |
+          if ! git diff --quiet; then
+            echo "Generated files are out of date. Run 'make manifests generate helm-update-crds' and commit."
+            git diff
+            exit 1
+          fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,15 +10,18 @@ concurrency:
   group: ci-${{ github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
+permissions: {}
 
 jobs:
   test:
     name: Test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@v5
         with:
@@ -30,8 +33,12 @@ jobs:
   lint:
     name: Lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@v5
         with:
@@ -40,13 +47,17 @@ jobs:
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v7
         with:
-          version: latest
+          version: v2.12.2
 
   helm-lint:
     name: Helm Lint
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Lint Helm chart
         run: make helm-lint
@@ -54,8 +65,12 @@ jobs:
   generated:
     name: Generated Code
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-go@v5
         with:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,134 @@
+version: "2"
+linters:
+  default: all
+  disable:
+    - cyclop
+    - depguard
+    - err113
+    - exhaustruct
+    - forbidigo
+    - funlen
+    - gochecknoglobals
+    - gochecknoinits
+    - gocognit
+    - godox
+    - gomoddirectives
+    - mnd
+    - nestif
+    - nilnil
+    - nlreturn
+    - paralleltest
+    - tagliatelle
+    - varnamelen
+    - wrapcheck
+    - wsl
+    - wsl_v5
+    - funcorder
+    - godoclint
+    - gomodguard
+    - noinlineerr
+  settings:
+    errcheck:
+      check-type-assertions: true
+    exhaustive:
+      check:
+        - switch
+      default-signifies-exhaustive: true
+    funlen:
+      lines: 100
+      statements: 100
+      ignore-comments: true
+    goconst:
+      ignore-string-values:
+        - "true"
+        - "false"
+    gocritic:
+      enabled-checks:
+        - deferInLoop
+        - unnecessaryDefer
+    gocyclo:
+      min-complexity: 30
+    importas:
+      alias:
+        - pkg: k8s.io/apimachinery/pkg/api/errors
+          alias: k8serr
+        - pkg: k8s.io/api/(\w+)/(v[\w\d]+)
+          alias: $1$2
+        - pkg: github.com/openshift/api/(\w+)/(v[\w\d]+)
+          alias: $1$2
+    lll:
+      line-length: 180
+    nolintlint:
+      require-specific: true
+      allow-no-explanation:
+        - funlen
+        - lll
+    perfsprint:
+      sprintf1: false
+      strconcat: false
+    revive:
+      rules:
+        - name: dot-imports
+          arguments:
+            - allowedPackages: []
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    rules:
+      - linters:
+          - dupl
+          - goconst
+          - unparam
+        path: (.+)_test\.go
+      - linters:
+          - testpackage
+        path: (.+)_test\.go
+      - linters:
+          - lll
+        source: "^//\\+?kubebuilder:"
+      - linters:
+          - gosec
+        text: "G101:"
+        path: (.+)_test\.go
+      - linters:
+          - goconst
+        path: internal/controller/(gvk|templatedata)
+      - linters:
+          - lll
+        source: "^// \\+kubebuilder:rbac:"
+      - linters:
+          - staticcheck
+        text: "ST1005:"
+      - linters:
+          - staticcheck
+        text: "SA1019:.*client\\.Apply"
+    paths:
+      - api
+      - third_party$
+      - builtin$
+      - examples$
+formatters:
+  enable:
+    - gci
+    - gofmt
+    - goimports
+  settings:
+    gci:
+      sections:
+        - standard
+        - default
+        - prefix(github.com/opendatahub-io/odh-observability)
+        - blank
+        - dot
+      custom-order: true
+  exclusions:
+    generated: lax
+    paths:
+      - api
+      - third_party$
+      - builtin$
+      - examples$

--- a/Makefile
+++ b/Makefile
@@ -132,4 +132,4 @@ $(CONTROLLER_GEN): $(LOCALBIN)
 .PHONY: golangci-lint
 golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
 $(GOLANGCI_LINT): $(LOCALBIN)
-	test -s $(LOCALBIN)/golangci-lint || GOBIN=$(LOCALBIN) go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
+	test -s "$(GOLANGCI_LINT)" || GOBIN="$(LOCALBIN)" go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.12.2

--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,10 @@ unit-test: ## Run unit tests (no codegen prerequisites).
 test-verbose: ## Run unit tests with verbose output.
 	go test -v $(shell go list ./... | grep -v /tests/e2e)
 
+.PHONY: lint
+lint: golangci-lint ## Run golangci-lint against code.
+	$(GOLANGCI_LINT) run
+
 .PHONY: e2e-test
 e2e-test: ## Run e2e tests against a cluster (requires KUBECONFIG).
 	go test ./tests/e2e/ -v -timeout 120m -count=1 $(E2E_TEST_FLAGS)
@@ -118,8 +122,14 @@ $(LOCALBIN):
 	mkdir -p $(LOCALBIN)
 
 CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
+GOLANGCI_LINT ?= $(LOCALBIN)/golangci-lint
 
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.
 $(CONTROLLER_GEN): $(LOCALBIN)
 	test -s $(LOCALBIN)/controller-gen || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-tools/cmd/controller-gen@latest
+
+.PHONY: golangci-lint
+golangci-lint: $(GOLANGCI_LINT) ## Download golangci-lint locally if necessary.
+$(GOLANGCI_LINT): $(LOCALBIN)
+	test -s $(LOCALBIN)/golangci-lint || GOBIN=$(LOCALBIN) go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -20,6 +20,8 @@ import (
 	"flag"
 	"os"
 
+	"github.com/opendatahub-io/odh-platform-utilities/pkg/deploy"
+	routev1 "github.com/openshift/api/route/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -36,9 +38,6 @@ import (
 	metricsserver "sigs.k8s.io/controller-runtime/pkg/metrics/server"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
-
-	"github.com/opendatahub-io/odh-platform-utilities/pkg/deploy"
-	routev1 "github.com/openshift/api/route/v1"
 
 	v1alpha1 "github.com/opendatahub-io/odh-observability/api/v1alpha1"
 	moncontroller "github.com/opendatahub-io/odh-observability/internal/controller"

--- a/internal/controller/actions.go
+++ b/internal/controller/actions.go
@@ -19,9 +19,12 @@ package controller
 import (
 	"context"
 	"embed"
+	"errors"
 	"fmt"
 	"os"
+	"slices"
 
+	rendertemplate "github.com/opendatahub-io/odh-platform-utilities/pkg/render/template"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
@@ -33,7 +36,6 @@ import (
 	v1alpha1 "github.com/opendatahub-io/odh-observability/api/v1alpha1"
 	"github.com/opendatahub-io/odh-observability/internal/controller/conditions"
 	"github.com/opendatahub-io/odh-observability/internal/controller/gvk"
-	rendertemplate "github.com/opendatahub-io/odh-platform-utilities/pkg/render/template"
 )
 
 const (
@@ -636,18 +638,12 @@ func ensureWebhookEnabled(
 	}
 
 	if len(dep.Spec.Template.Spec.Containers) == 0 {
-		return fmt.Errorf("operator Deployment has no containers")
+		return errors.New("operator Deployment has no containers")
 	}
 
 	container := &dep.Spec.Template.Spec.Containers[0]
 
-	hasWebhookArg := false
-	for _, arg := range container.Args {
-		if arg == webhookArgEnabled {
-			hasWebhookArg = true
-			break
-		}
-	}
+	hasWebhookArg := slices.Contains(container.Args, webhookArgEnabled)
 
 	hasPort := false
 	for _, p := range container.Ports {
@@ -750,7 +746,7 @@ func isLokiStackReady(ctx context.Context, c client.Client, monitoring *v1alpha1
 	}
 
 	for _, cond := range conditions {
-		condMap, ok := cond.(map[string]interface{})
+		condMap, ok := cond.(map[string]any)
 		if !ok {
 			continue
 		}

--- a/internal/controller/conditions/conditions.go
+++ b/internal/controller/conditions/conditions.go
@@ -199,6 +199,8 @@ func (cm *ConditionsManager) AggregateReady() {
 			continue
 		}
 		switch c.Status {
+		case metav1.ConditionTrue:
+			// Feature is healthy — nothing to do.
 		case metav1.ConditionFalse:
 			if c.Severity != platformcommon.ConditionSeverityInfo {
 				anyFailing = true

--- a/internal/controller/helpers.go
+++ b/internal/controller/helpers.go
@@ -21,14 +21,13 @@ import (
 	"encoding/base64"
 	"fmt"
 
+	routev1 "github.com/openshift/api/route/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
-
-	routev1 "github.com/openshift/api/route/v1"
 
 	v1alpha1 "github.com/opendatahub-io/odh-observability/api/v1alpha1"
 )

--- a/internal/controller/monitoring_reconciler.go
+++ b/internal/controller/monitoring_reconciler.go
@@ -244,7 +244,7 @@ func (r *MonitoringReconciler) reconcile(ctx context.Context, monitoring *v1alph
 	if err := r.Deployer.Deploy(ctx, deploy.DeployInput{
 		Client:    r.Client,
 		Owner:     monitoring,
-		Release:   deploy.ReleaseInfo{Type: "OpenDataHub", Version: operatorVersion()},
+		Release:   deploy.ReleaseInfo{Type: platformType, Version: operatorVersion()},
 		Resources: desired,
 	}); err != nil {
 		return ctrl.Result{}, fmt.Errorf("applying resources: %w", err)
@@ -340,7 +340,7 @@ func (r *MonitoringReconciler) collectGarbage(ctx context.Context, monitoring *v
 		DiscoveryClient: r.DiscoveryClient,
 		Owner:           monitoring,
 		Version:         operatorVersion(),
-		PlatformType:    "OpenDataHub",
+		PlatformType:    platformType,
 	})
 }
 
@@ -362,7 +362,7 @@ func (r *MonitoringReconciler) deleteAllOwned(ctx context.Context, monitoring *v
 		DiscoveryClient: r.DiscoveryClient,
 		Owner:           monitoring,
 		Version:         operatorVersion(),
-		PlatformType:    "OpenDataHub",
+		PlatformType:    platformType,
 	})
 }
 

--- a/internal/controller/monitoring_reconciler.go
+++ b/internal/controller/monitoring_reconciler.go
@@ -23,6 +23,12 @@ import (
 	"os"
 	"time"
 
+	platformcommon "github.com/opendatahub-io/odh-platform-utilities/api/common"
+	"github.com/opendatahub-io/odh-platform-utilities/pkg/controller/gc"
+	"github.com/opendatahub-io/odh-platform-utilities/pkg/deploy"
+	odhLabels "github.com/opendatahub-io/odh-platform-utilities/pkg/metadata/labels"
+	rendertemplate "github.com/opendatahub-io/odh-platform-utilities/pkg/render/template"
+	routev1 "github.com/openshift/api/route/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	corev1 "k8s.io/api/core/v1"
@@ -46,24 +52,19 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	platformcommon "github.com/opendatahub-io/odh-platform-utilities/api/common"
-	"github.com/opendatahub-io/odh-platform-utilities/pkg/controller/gc"
-	"github.com/opendatahub-io/odh-platform-utilities/pkg/deploy"
-	odhLabels "github.com/opendatahub-io/odh-platform-utilities/pkg/metadata/labels"
-	rendertemplate "github.com/opendatahub-io/odh-platform-utilities/pkg/render/template"
-	routev1 "github.com/openshift/api/route/v1"
-
 	v1alpha1 "github.com/opendatahub-io/odh-observability/api/v1alpha1"
 	"github.com/opendatahub-io/odh-observability/internal/controller/conditions"
 )
 
 const (
 	monitoringFinalizer = "monitoring.opendatahub.io/cleanup"
+	platformType        = "OpenDataHub"
 )
 
 // MonitoringReconciler reconciles a Monitoring object.
 type MonitoringReconciler struct {
 	client.Client
+
 	Scheme          *runtime.Scheme
 	Deployer        *deploy.Deployer
 	DynamicClient   dynamic.Interface
@@ -150,8 +151,8 @@ func (r *MonitoringReconciler) reconcile(ctx context.Context, monitoring *v1alph
 	cm := conditions.NewConditionsManager(monitoring, monitoring.Generation)
 
 	defer func() {
-		monitoring.Status.Status.ObservedGeneration = monitoring.Generation
-		monitoring.Status.Status.Phase = cm.Phase()
+		monitoring.Status.ObservedGeneration = monitoring.Generation
+		monitoring.Status.Phase = cm.Phase()
 		monitoring.SetReleaseStatus(platformcommon.ComponentReleaseStatus{
 			Releases: []platformcommon.ComponentRelease{{
 				Name:    v1alpha1.MonitoringServiceName,
@@ -239,7 +240,7 @@ func (r *MonitoringReconciler) reconcile(ctx context.Context, monitoring *v1alph
 	if err := r.Deployer.Deploy(ctx, deploy.DeployInput{
 		Client:    r.Client,
 		Owner:     monitoring,
-		Release:   deploy.ReleaseInfo{Type: "OpenDataHub", Version: os.Getenv("OPERATOR_VERSION")},
+		Release:   deploy.ReleaseInfo{Type: platformType, Version: os.Getenv("OPERATOR_VERSION")},
 		Resources: desired,
 	}); err != nil {
 		return ctrl.Result{}, fmt.Errorf("applying resources: %w", err)
@@ -273,7 +274,8 @@ func (r *MonitoringReconciler) reconcile(ctx context.Context, monitoring *v1alph
 			return ctrl.Result{}, err
 		}
 		if lokiReady {
-			monitoring.Status.UsageLogsEndpoint = data["UsageLogsEndpoint"].(string)
+			endpoint, _ := data["UsageLogsEndpoint"].(string)
+			monitoring.Status.UsageLogsEndpoint = endpoint
 		} else {
 			monitoring.Status.UsageLogsEndpoint = ""
 			requeueNeeded = true // Requeue to check again when LokiStack becomes ready
@@ -300,7 +302,7 @@ type resourceKey struct {
 // collectGarbage deletes owned resources not in the desired set using API discovery.
 func (r *MonitoringReconciler) collectGarbage(ctx context.Context, monitoring *v1alpha1.Monitoring, desired []unstructured.Unstructured) error {
 	if monitoring.Spec.Namespace == "" {
-		return fmt.Errorf("monitoring.Spec.Namespace is empty, cannot safely perform garbage collection")
+		return errors.New("monitoring.Spec.Namespace is empty, cannot safely perform garbage collection")
 	}
 
 	desiredSet := make(map[resourceKey]struct{}, len(desired))
@@ -334,14 +336,14 @@ func (r *MonitoringReconciler) collectGarbage(ctx context.Context, monitoring *v
 		DiscoveryClient: r.DiscoveryClient,
 		Owner:           monitoring,
 		Version:         os.Getenv("OPERATOR_VERSION"),
-		PlatformType:    "OpenDataHub",
+		PlatformType:    platformType,
 	})
 }
 
 // deleteAllOwned removes all resources owned by this controller (used on Removed state).
 func (r *MonitoringReconciler) deleteAllOwned(ctx context.Context, monitoring *v1alpha1.Monitoring) error {
 	if monitoring.Spec.Namespace == "" {
-		return fmt.Errorf("monitoring.Spec.Namespace is empty, cannot safely delete owned resources")
+		return errors.New("monitoring.Spec.Namespace is empty, cannot safely delete owned resources")
 	}
 
 	collector := gc.New(
@@ -356,7 +358,7 @@ func (r *MonitoringReconciler) deleteAllOwned(ctx context.Context, monitoring *v
 		DiscoveryClient: r.DiscoveryClient,
 		Owner:           monitoring,
 		Version:         os.Getenv("OPERATOR_VERSION"),
-		PlatformType:    "OpenDataHub",
+		PlatformType:    platformType,
 	})
 }
 

--- a/internal/controller/monitoring_reconciler_test.go
+++ b/internal/controller/monitoring_reconciler_test.go
@@ -20,6 +20,9 @@ import (
 	"context"
 	"testing"
 
+	platformcommon "github.com/opendatahub-io/odh-platform-utilities/api/common"
+	"github.com/opendatahub-io/odh-platform-utilities/pkg/deploy"
+	routev1 "github.com/openshift/api/route/v1"
 	appsv1 "k8s.io/api/apps/v1"
 	batchv1 "k8s.io/api/batch/v1"
 	networkingv1 "k8s.io/api/networking/v1"
@@ -35,10 +38,6 @@ import (
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
-
-	platformcommon "github.com/opendatahub-io/odh-platform-utilities/api/common"
-	"github.com/opendatahub-io/odh-platform-utilities/pkg/deploy"
-	routev1 "github.com/openshift/api/route/v1"
 
 	v1alpha1 "github.com/opendatahub-io/odh-observability/api/v1alpha1"
 )
@@ -59,7 +58,7 @@ func newTestScheme(t *testing.T) *runtime.Scheme {
 
 func newTestReconciler(t *testing.T, s *runtime.Scheme, c client.Client) *MonitoringReconciler {
 	t.Helper()
-	cs := fakeclientset.NewSimpleClientset()
+	cs := fakeclientset.NewSimpleClientset() //nolint:staticcheck // NewClientset requires generated apply configs not available in this project
 	return &MonitoringReconciler{
 		Client:          c,
 		Scheme:          s,
@@ -99,7 +98,7 @@ func TestReconcile_Removed(t *testing.T) {
 	}
 
 	var ready, provisioning string
-	for _, c := range m.Status.Status.Conditions {
+	for _, c := range m.Status.Conditions {
 		switch c.Type {
 		case string(platformcommon.ConditionTypeReady):
 			ready = string(c.Status)
@@ -140,7 +139,7 @@ func TestReconcile_PreconditionsFailed(t *testing.T) {
 	}
 
 	var ready, monAvail string
-	for _, c := range m.Status.Status.Conditions {
+	for _, c := range m.Status.Conditions {
 		switch c.Type {
 		case string(platformcommon.ConditionTypeReady):
 			ready = string(c.Status)
@@ -179,7 +178,7 @@ func TestReconcile_NothingConfigured(t *testing.T) {
 	}
 
 	var ready, degraded string
-	for _, c := range m.Status.Status.Conditions {
+	for _, c := range m.Status.Conditions {
 		switch c.Type {
 		case string(platformcommon.ConditionTypeReady):
 			ready = string(c.Status)
@@ -215,7 +214,9 @@ func TestSyncStatusURL_RoutePresent(t *testing.T) {
 	}
 
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(m, route).WithStatusSubresource(route).Build()
-	syncStatusURL(context.Background(), c, m)
+	if err := syncStatusURL(context.Background(), c, m); err != nil {
+		t.Fatalf("syncStatusURL returned error: %v", err)
+	}
 
 	want := "https://thanos.example.com"
 	if m.Status.URL != want {
@@ -231,7 +232,9 @@ func TestSyncStatusURL_RouteMissing(t *testing.T) {
 	m.Status.URL = "https://stale.example.com"
 
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(m).Build()
-	syncStatusURL(context.Background(), c, m)
+	if err := syncStatusURL(context.Background(), c, m); err != nil {
+		t.Fatalf("syncStatusURL returned error: %v", err)
+	}
 
 	if m.Status.URL != "" {
 		t.Errorf("Status.URL: want empty, got %q", m.Status.URL)
@@ -245,7 +248,9 @@ func TestSyncStatusURL_NoMetrics(t *testing.T) {
 	m.Status.URL = "https://stale.example.com"
 
 	c := fake.NewClientBuilder().WithScheme(s).WithObjects(m).Build()
-	syncStatusURL(context.Background(), c, m)
+	if err := syncStatusURL(context.Background(), c, m); err != nil {
+		t.Fatalf("syncStatusURL: %v", err)
+	}
 
 	if m.Status.URL != "" {
 		t.Errorf("Status.URL: want empty, got %q", m.Status.URL)
@@ -305,7 +310,7 @@ func TestReconcile_ObservedGenerationSet(t *testing.T) {
 		t.Fatalf("reconcile returned error: %v", err)
 	}
 
-	if got := m.Status.Status.ObservedGeneration; got != 7 {
+	if got := m.Status.ObservedGeneration; got != 7 {
 		t.Errorf("ObservedGeneration: want 7, got %d", got)
 	}
 }

--- a/internal/controller/templatedata.go
+++ b/internal/controller/templatedata.go
@@ -29,6 +29,7 @@ import (
 	"strings"
 
 	"github.com/hashicorp/go-multierror"
+	"github.com/opendatahub-io/odh-platform-utilities/pkg/cluster/openshift"
 	"gopkg.in/yaml.v3"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -41,7 +42,6 @@ import (
 	v1alpha1 "github.com/opendatahub-io/odh-observability/api/v1alpha1"
 	"github.com/opendatahub-io/odh-observability/internal/controller/conditions"
 	"github.com/opendatahub-io/odh-observability/internal/controller/gvk"
-	"github.com/opendatahub-io/odh-platform-utilities/pkg/cluster/openshift"
 )
 
 const (

--- a/internal/webhook/mutating_test.go
+++ b/internal/webhook/mutating_test.go
@@ -83,8 +83,14 @@ func monitoringCR() *v1alpha1.Monitoring {
 	}
 }
 
-func makeAdmissionRequest(op admissionv1.Operation, kind metav1.GroupVersionKind, obj *unstructured.Unstructured) admission.Request {
-	raw, _ := json.Marshal(obj)
+func makeAdmissionRequest(t *testing.T, op admissionv1.Operation, kind metav1.GroupVersionKind, obj *unstructured.Unstructured) admission.Request {
+	t.Helper()
+
+	raw, err := json.Marshal(obj)
+	if err != nil {
+		t.Fatalf("failed to marshal admission request object: %v", err)
+	}
+
 	return admission.Request{
 		AdmissionRequest: admissionv1.AdmissionRequest{
 			Operation: op,
@@ -100,7 +106,7 @@ func TestHandle_NilDecoder(t *testing.T) {
 		Decoder: nil,
 	}
 
-	req := makeAdmissionRequest(admissionv1.Create, metav1.GroupVersionKind{
+	req := makeAdmissionRequest(t, admissionv1.Create, metav1.GroupVersionKind{
 		Group: "monitoring.coreos.com", Version: "v1", Kind: "ServiceMonitor",
 	}, newServiceMonitor("test-ns", "sm", nil))
 
@@ -116,7 +122,7 @@ func TestHandle_NilClient(t *testing.T) {
 		Decoder: admission.NewDecoder(newTestScheme()),
 	}
 
-	req := makeAdmissionRequest(admissionv1.Create, metav1.GroupVersionKind{
+	req := makeAdmissionRequest(t, admissionv1.Create, metav1.GroupVersionKind{
 		Group: "monitoring.coreos.com", Version: "v1", Kind: "ServiceMonitor",
 	}, newServiceMonitor("test-ns", "sm", nil))
 
@@ -137,7 +143,10 @@ func TestHandle_UnexpectedKind(t *testing.T) {
 	obj.SetGroupVersionKind(gvk.CoreosServiceMonitor)
 	obj.SetNamespace("test-ns")
 	obj.SetName("sm")
-	raw, _ := json.Marshal(obj)
+	raw, err := json.Marshal(obj)
+	if err != nil {
+		t.Fatalf("failed to marshal object: %v", err)
+	}
 
 	req := admission.Request{
 		AdmissionRequest: admissionv1.AdmissionRequest{
@@ -167,7 +176,7 @@ func TestHandle_NamespaceNotLabeled(t *testing.T) {
 	}
 
 	sm := newServiceMonitor("unlabeled-ns", "my-sm", nil)
-	req := makeAdmissionRequest(admissionv1.Create, metav1.GroupVersionKind{
+	req := makeAdmissionRequest(t, admissionv1.Create, metav1.GroupVersionKind{
 		Group: "monitoring.coreos.com", Version: "v1", Kind: "ServiceMonitor",
 	}, sm)
 
@@ -194,7 +203,7 @@ func TestHandle_InjectsLabelOnServiceMonitor(t *testing.T) {
 	}
 
 	sm := newServiceMonitor("monitored-ns", "my-sm", nil)
-	req := makeAdmissionRequest(admissionv1.Create, metav1.GroupVersionKind{
+	req := makeAdmissionRequest(t, admissionv1.Create, metav1.GroupVersionKind{
 		Group: "monitoring.coreos.com", Version: "v1", Kind: "ServiceMonitor",
 	}, sm)
 
@@ -235,7 +244,7 @@ func TestHandle_InjectsLabelOnPodMonitor(t *testing.T) {
 	}
 
 	pm := newPodMonitor("monitored-ns", "my-pm", nil)
-	req := makeAdmissionRequest(admissionv1.Create, metav1.GroupVersionKind{
+	req := makeAdmissionRequest(t, admissionv1.Create, metav1.GroupVersionKind{
 		Group: "monitoring.coreos.com", Version: "v1", Kind: "PodMonitor",
 	}, pm)
 
@@ -268,7 +277,7 @@ func TestHandle_PreservesExistingLabel(t *testing.T) {
 		labelMonitoring: "true",
 		"other":         "label",
 	})
-	req := makeAdmissionRequest(admissionv1.Create, metav1.GroupVersionKind{
+	req := makeAdmissionRequest(t, admissionv1.Create, metav1.GroupVersionKind{
 		Group: "monitoring.coreos.com", Version: "v1", Kind: "ServiceMonitor",
 	}, sm)
 
@@ -294,7 +303,7 @@ func TestHandle_MonitoringCRMissing(t *testing.T) {
 	}
 
 	sm := newServiceMonitor("monitored-ns", "my-sm", nil)
-	req := makeAdmissionRequest(admissionv1.Create, metav1.GroupVersionKind{
+	req := makeAdmissionRequest(t, admissionv1.Create, metav1.GroupVersionKind{
 		Group: "monitoring.coreos.com", Version: "v1", Kind: "ServiceMonitor",
 	}, sm)
 
@@ -313,7 +322,7 @@ func TestHandle_DeleteOperation(t *testing.T) {
 	}
 
 	sm := newServiceMonitor("test-ns", "sm", nil)
-	req := makeAdmissionRequest(admissionv1.Delete, metav1.GroupVersionKind{
+	req := makeAdmissionRequest(t, admissionv1.Delete, metav1.GroupVersionKind{
 		Group: "monitoring.coreos.com", Version: "v1", Kind: "ServiceMonitor",
 	}, sm)
 

--- a/tests/e2e/helper_test.go
+++ b/tests/e2e/helper_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	common "github.com/opendatahub-io/odh-platform-utilities/api/common"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -13,9 +14,8 @@ import (
 
 	"github.com/opendatahub-io/odh-observability/internal/controller/gvk"
 	jq "github.com/opendatahub-io/odh-observability/tests/e2e/matchers/jq"
-	common "github.com/opendatahub-io/odh-platform-utilities/api/common"
 
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega" //nolint:revive // dot import is idiomatic for gomega matchers
 )
 
 // Constants for monitoring resource names.
@@ -123,21 +123,6 @@ func (tc *MonitoringTestCtx) setupMetrics(t *testing.T) {
 	tc.updateMonitoringConfig(
 		withManagementState(common.Managed),
 		tc.withMetricsConfig(),
-	)
-}
-
-// setupTraces enables traces with the specified backend and optional secret.
-func (tc *MonitoringTestCtx) setupTraces(t *testing.T, backend, secretName string) {
-	t.Helper()
-
-	size := ""
-	if backend == TracesStorageBackendPV {
-		size = TracesStorageSize1Gi
-	}
-
-	tc.updateMonitoringConfig(
-		withManagementState(common.Managed),
-		withMonitoringTraces(backend, secretName, size, DefaultRetention),
 	)
 }
 
@@ -370,6 +355,7 @@ func detectExpectedReplicas(t *testing.T, tc *TestContext) int {
 
 // createDummySecret creates a test secret for the specified backend type.
 // For Tempo backends, this routes to tempo-specific helpers.
+//
 // Deprecated: Use createTempoS3Secret, createTempoGCSSecret, or createLokiS3Secret directly.
 func (tc *MonitoringTestCtx) createDummySecret(t *testing.T, backendType, secretName, namespace string) {
 	t.Helper()

--- a/tests/e2e/matchers/jq/jq_support.go
+++ b/tests/e2e/matchers/jq/jq_support.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"reflect"
+	"slices"
 	"strings"
 
 	"github.com/itchyny/gojq"
@@ -56,6 +57,7 @@ func Transform(format string, args ...any) TransformFn {
 	}
 }
 
+//nolint:ireturn // generic helper intentionally returns type parameter T
 func ExtractValue[T any](in any, expression string) (T, error) {
 	var result T
 
@@ -108,8 +110,8 @@ func formattedMessage(comparisonMessage string, failurePath []any) string {
 func formattedFailurePath(failurePath []any) string {
 	formattedPaths := make([]string, 0)
 
-	for i := len(failurePath) - 1; i >= 0; i-- {
-		switch p := failurePath[i].(type) {
+	for i, v := range slices.Backward(failurePath) {
+		switch p := v.(type) {
 		case int:
 			val := fmt.Sprintf(`[%d]`, p)
 			formattedPaths = append(formattedPaths, val)
@@ -132,7 +134,7 @@ func toType(in any) (any, error) {
 	if !valof.IsValid() {
 		return nil, nil
 	}
-	if valof.Kind() == reflect.Ptr && valof.IsNil() {
+	if valof.Kind() == reflect.Pointer && valof.IsNil() {
 		return nil, nil
 	}
 

--- a/tests/e2e/monitoring_negative_test.go
+++ b/tests/e2e/monitoring_negative_test.go
@@ -3,15 +3,15 @@ package e2e_test
 import (
 	"testing"
 
+	common "github.com/opendatahub-io/odh-platform-utilities/api/common"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/opendatahub-io/odh-observability/internal/controller/conditions"
 	"github.com/opendatahub-io/odh-observability/internal/controller/gvk"
 	jq "github.com/opendatahub-io/odh-observability/tests/e2e/matchers/jq"
-	common "github.com/opendatahub-io/odh-platform-utilities/api/common"
 
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega" //nolint:revive // dot import is idiomatic for gomega matchers
 )
 
 func (tc *MonitoringTestCtx) runNegativeConditionTests(t *testing.T) {

--- a/tests/e2e/monitoring_test.go
+++ b/tests/e2e/monitoring_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	gTypes "github.com/onsi/gomega/types"
+	common "github.com/opendatahub-io/odh-platform-utilities/api/common"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -14,9 +15,8 @@ import (
 	"github.com/opendatahub-io/odh-observability/internal/controller/conditions"
 	"github.com/opendatahub-io/odh-observability/internal/controller/gvk"
 	jq "github.com/opendatahub-io/odh-observability/tests/e2e/matchers/jq"
-	common "github.com/opendatahub-io/odh-platform-utilities/api/common"
 
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega" //nolint:revive // dot import is idiomatic for gomega
 )
 
 func monitoringTestSuite(t *testing.T) {

--- a/tests/e2e/monitoring_usage_logs_test.go
+++ b/tests/e2e/monitoring_usage_logs_test.go
@@ -3,15 +3,15 @@ package e2e_test
 import (
 	"testing"
 
+	common "github.com/opendatahub-io/odh-platform-utilities/api/common"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/opendatahub-io/odh-observability/internal/controller/conditions"
 	"github.com/opendatahub-io/odh-observability/internal/controller/gvk"
 	jq "github.com/opendatahub-io/odh-observability/tests/e2e/matchers/jq"
-	common "github.com/opendatahub-io/odh-platform-utilities/api/common"
 
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega" //nolint:revive // dot import is idiomatic for gomega matchers
 )
 
 // ========================================================================

--- a/tests/e2e/monitoring_webhook_test.go
+++ b/tests/e2e/monitoring_webhook_test.go
@@ -4,6 +4,7 @@ import (
 	"maps"
 	"testing"
 
+	common "github.com/opendatahub-io/odh-platform-utilities/api/common"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -11,9 +12,8 @@ import (
 
 	"github.com/opendatahub-io/odh-observability/internal/controller/gvk"
 	jq "github.com/opendatahub-io/odh-observability/tests/e2e/matchers/jq"
-	common "github.com/opendatahub-io/odh-platform-utilities/api/common"
 
-	. "github.com/onsi/gomega"
+	. "github.com/onsi/gomega" //nolint:revive // dot import is idiomatic for gomega matchers
 )
 
 const (

--- a/tests/e2e/resource_options_test.go
+++ b/tests/e2e/resource_options_test.go
@@ -2,6 +2,7 @@ package e2e_test
 
 import (
 	"fmt"
+	"maps"
 	"testing"
 	"time"
 
@@ -85,9 +86,7 @@ func (ro *ResourceOptions) buildObject() *unstructured.Unstructured {
 	u.SetNamespace(ro.NN.Namespace)
 
 	if ro.ObjectContent != nil {
-		for k, v := range ro.ObjectContent {
-			u.Object[k] = v
-		}
+		maps.Copy(u.Object, ro.ObjectContent)
 	}
 
 	return u
@@ -175,12 +174,16 @@ func WithRemoveFinalizersOnDelete(remove bool) ResourceOpts {
 }
 
 func WithCleanup(t *testing.T) ResourceOpts {
+	t.Helper()
+
 	return func(ro *ResourceOptions) {
 		ro.CleanupT = t
 	}
 }
 
 func WithTest(t *testing.T) ResourceOpts {
+	t.Helper()
+
 	return func(ro *ResourceOptions) {
 		ro.t = t
 	}

--- a/tests/e2e/test_context_test.go
+++ b/tests/e2e/test_context_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
 	k8serr "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -16,17 +15,17 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	ctrlcfg "sigs.k8s.io/controller-runtime/pkg/client/config"
 
-	. "github.com/onsi/gomega"
-
 	"github.com/opendatahub-io/odh-observability/internal/controller/gvk"
 	jq "github.com/opendatahub-io/odh-observability/tests/e2e/matchers/jq"
+
+	. "github.com/onsi/gomega" //nolint:revive // dot import is idiomatic for gomega matchers
 )
 
 type TestContext struct {
 	t                   *testing.T
 	client              client.Client
-	ctx                 context.Context
-	g                   *gomega.WithT
+	ctx                 context.Context //nolint:containedctx // TestContext carries a long-lived background context for the entire test suite
+	g                   *WithT
 	Timeouts            TestTimeouts
 	MonitoringNamespace string
 	MonitoringCRName    string
@@ -34,6 +33,7 @@ type TestContext struct {
 	DefaultResourceOpts []ResourceOpts
 }
 
+//nolint:ireturn // returning client.Client interface is the intended design
 func (tc *TestContext) Client() client.Client {
 	return tc.client
 }
@@ -55,7 +55,7 @@ func NewTestContext(t *testing.T) (*TestContext, error) {
 		return nil, fmt.Errorf("failed to initialize client: %w", err)
 	}
 
-	g := gomega.NewWithT(t)
+	g := NewWithT(t)
 	g.SetDefaultEventuallyTimeout(testOpts.Timeouts.defaultEventuallyTimeout)
 	g.SetDefaultEventuallyPollingInterval(testOpts.Timeouts.defaultEventuallyPollInterval)
 	g.SetDefaultConsistentlyDuration(testOpts.Timeouts.defaultConsistentlyTimeout)
@@ -317,11 +317,13 @@ func (tc *TestContext) EventuallyResourcePatched(opts ...ResourceOpts) *unstruct
 	}
 
 	if ro.Condition != nil {
-		ensureOpts := []ResourceOpts{
+		timeoutOpts := ro.withTimeoutOpts()
+		ensureOpts := make([]ResourceOpts, 0, 2+len(timeoutOpts))
+		ensureOpts = append(ensureOpts,
 			WithMinimalObject(ro.GVK, ro.NN),
 			WithCondition(ro.Condition),
-		}
-		ensureOpts = append(ensureOpts, ro.withTimeoutOpts()...)
+		)
+		ensureOpts = append(ensureOpts, timeoutOpts...)
 		tc.EnsureResourceExists(ensureOpts...)
 	}
 
@@ -421,8 +423,10 @@ func (tc *TestContext) DeleteResource(opts ...ResourceOpts) {
 	}
 
 	if ro.WaitForDeletion {
-		goneOpts := []ResourceOpts{WithMinimalObject(ro.GVK, ro.NN)}
-		goneOpts = append(goneOpts, ro.withTimeoutOpts()...)
+		timeoutOpts := ro.withTimeoutOpts()
+		goneOpts := make([]ResourceOpts, 0, 1+len(timeoutOpts))
+		goneOpts = append(goneOpts, WithMinimalObject(ro.GVK, ro.NN))
+		goneOpts = append(goneOpts, timeoutOpts...)
 		tc.EnsureResourceGone(goneOpts...)
 	}
 }
@@ -433,10 +437,8 @@ func (tc *TestContext) DeleteResources(opts ...ResourceOpts) {
 	u := &unstructured.Unstructured{}
 	u.SetGroupVersionKind(ro.GVK)
 
-	deleteOpts := []client.DeleteAllOfOption{}
-	for _, o := range ro.DeleteAllOfOptions {
-		deleteOpts = append(deleteOpts, o)
-	}
+	deleteOpts := make([]client.DeleteAllOfOption, 0, len(ro.DeleteAllOfOptions))
+	deleteOpts = append(deleteOpts, ro.DeleteAllOfOptions...)
 
 	err := tc.client.DeleteAllOf(tc.ctx, u, deleteOpts...)
 	if err != nil && !k8serr.IsNotFound(err) {
@@ -532,7 +534,7 @@ func StopErr(err error, format string, args ...any) error {
 		msg = fmt.Sprintf(format, args...)
 	}
 
-	return gomega.StopTrying(msg).Wrap(err)
+	return StopTrying(msg).Wrap(err)
 }
 
 // detectMonitoringNamespace reads spec.namespace from the Monitoring CR.


### PR DESCRIPTION
## Description

Adds a GitHub Actions CI workflow and golangci-lint configuration to the repository. The CI workflow runs on all PRs to `main` and on pushes to `main`, with four jobs:

- **Test** — runs `make test` (codegen, fmt, vet, unit tests with coverage)
- **Lint** — runs golangci-lint via the official GitHub Action
- **Helm Lint** — runs `make helm-lint` to validate the Helm chart
- **Generated Code** — runs `make manifests generate helm-update-crds` and fails if the diff is dirty, catching forgotten codegen commits

Also includes a `make lint` target and local golangci-lint tool download so developers can run the same checks locally.

The second commit resolves all pre-existing lint issues in the codebase (import ordering, `errors.New` vs `fmt.Errorf`, `slices.Contains` modernization, unchecked error returns, deprecated API usage, etc.).

## How Has This Been Tested?

- Ran `make lint` locally — passes with 0 issues
- Ran `make unit-test` locally — all tests pass
- Ran `make helm-lint` locally — passes

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated checks for Go tests, linting, Helm chart validation, and generated-file consistency.
  * Added a local lint command for easier development checks.

* **Tests**
  * Improved test error handling and validation across unit and end-to-end tests.
  * Updated tests for current status and API behavior.

* **Refactor**
  * Standardized formatting, imports, error handling, and modern language utilities without changing runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->