### PR TITLE
chore: use floating v1 tag for disconnected readiness workflow

### DIFF
--- a/.github/workflows/disconnected-readiness.yml
+++ b/.github/workflows/disconnected-readiness.yml
@@ -8,6 +8,6 @@ jobs:
   check:
     permissions:
       contents: read
-    uses: opendatahub-io/disconnected-readiness-scorer/.github/workflows/disconnected-readiness-check.yml@28f88a60c184a9c29e823918f0fba56b32f577e1 # v1
+    uses: opendatahub-io/disconnected-readiness-scorer/.github/workflows/disconnected-readiness-check.yml@v1
     with:
       rules: ""


### PR DESCRIPTION
## Summary

- Switch the disconnected readiness workflow ref from a pinned commit SHA (28f88a6) to the floating v1 tag

## Why

The workflow is currently pinned to a specific commit SHA, which prevents it from receiving any updates to the reusable workflow. This means:

1. **Config exception decoupling** ([scorer PR #95](https://github.com/opendatahub-io/disconnected-readiness-scorer/pull/95)) — merged exceptions to config/config.yaml now take effect on the very next run without needing a scorer release. This repo cannot benefit from this while SHA-pinned.
2. **All other improvements** — bug fixes, new rules, report enhancements — none reach this repo until someone manually updates the SHA.

The v1 tag is a floating major-version tag managed by the scorer's [release workflow](https://github.com/opendatahub-io/disconnected-readiness-scorer/blob/main/.github/workflows/release.yml). It advances on each patch/minor release, following the same pattern as actions/checkout@v4. Breaking changes would only land in v2.

10 of 13 onboarded consumer repos already use @v1. This repo, models-as-a-service, and notebooks are the only ones still SHA-pinned.

See [RHOAIENG-79773](https://redhat.atlassian.net/browse/RHOAIENG-79773) for full context.

## Test plan

- [x] Verify the disconnected readiness check passes on this PR (self-testing — it runs the updated workflow)


[RHOAIENG-79773]: https://redhat.atlassian.net/browse/RHOAIENG-79773?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the disconnected-readiness validation workflow to use its stable version 1 release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->