### PR TITLE
fix(monitoring): move DCGM metric rename rules to metric_relabel_configs

### DIFF
--- a/internal/controller/otel_collector_template_test.go
+++ b/internal/controller/otel_collector_template_test.go
@@ -1,0 +1,65 @@
+package controller
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDCGMRenameRulesInMetricRelabelConfigs(t *testing.T) {
+	templateBytes, err := resourcesFS.ReadFile(OpenTelemetryCollectorTemplate)
+	if err != nil {
+		t.Fatalf("failed to read template: %v", err)
+	}
+
+	templateContent := string(templateBytes)
+
+	dcgmJob := extractSection(templateContent, "job_name: 'dcgm-exporter-accelerator-metrics'", "{{- end }}")
+	if dcgmJob == "" {
+		t.Fatal("dcgm-exporter-accelerator-metrics job must exist in template")
+	}
+
+	relabelSection := extractSection(dcgmJob, "relabel_configs:", "metric_relabel_configs:")
+	if relabelSection == "" {
+		t.Fatal("relabel_configs section must be extractable from dcgm job")
+	}
+	metricRelabelSection := extractSection(dcgmJob, "metric_relabel_configs:", "scrape_interval:")
+	if metricRelabelSection == "" {
+		t.Fatal("metric_relabel_configs section must be extractable from dcgm job")
+	}
+
+	dcgmRenameMetrics := []string{
+		"DCGM_FI_DEV_GPU_TEMP",
+		"DCGM_FI_DEV_GPU_UTIL",
+		"DCGM_FI_DEV_MEM_COPY_UTIL",
+		"DCGM_FI_DEV_FB_USED",
+		"DCGM_FI_DEV_FB_FREE",
+		"DCGM_FI_DEV_POWER_USAGE",
+		"DCGM_FI_DEV_SM_CLOCK",
+		"DCGM_FI_DEV_MEM_CLOCK",
+	}
+
+	for _, metric := range dcgmRenameMetrics {
+		if strings.Contains(relabelSection, metric) {
+			t.Errorf("rename rule for %s must not be in relabel_configs (__name__ unavailable at target-discovery stage)", metric)
+		}
+		if !strings.Contains(metricRelabelSection, metric) {
+			t.Errorf("rename rule for %s must be in metric_relabel_configs (post-scrape stage)", metric)
+		}
+	}
+
+	if strings.Contains(relabelSection, "__name__") {
+		t.Error("relabel_configs must not reference __name__ (unavailable at target-discovery stage)")
+	}
+}
+
+func extractSection(content, startMarker, endMarker string) string {
+	startIdx := strings.Index(content, startMarker)
+	if startIdx == -1 {
+		return ""
+	}
+	endIdx := strings.Index(content[startIdx:], endMarker)
+	if endIdx == -1 {
+		return content[startIdx:]
+	}
+	return content[startIdx : startIdx+endIdx]
+}

--- a/internal/controller/resources/opentelemetry-collector.tmpl.yaml
+++ b/internal/controller/resources/opentelemetry-collector.tmpl.yaml
@@ -85,6 +85,13 @@ spec:
                   source_labels: [__meta_kubernetes_pod_node_name]
                   target_label: node
                 - action: replace
+                  source_labels: [__meta_kubernetes_pod_label_app]
+                  target_label: component
+                - action: replace
+                  replacement: 'rhoai-accelerator-metrics'
+                  target_label: job
+              metric_relabel_configs:
+                - action: replace
                   regex: 'DCGM_FI_DEV_GPU_TEMP'
                   replacement: 'nvidia_gpu_temperature_celsius'
                   source_labels: [__name__]
@@ -124,23 +131,13 @@ spec:
                   replacement: 'nvidia_gpu_memory_clock_mhz'
                   source_labels: [__name__]
                   target_label: __name__
-                - action: replace
-                  source_labels: [__meta_kubernetes_pod_label_app]
-                  target_label: component
-                - action: replace
-                  replacement: 'rhoai-accelerator-metrics'
-                  target_label: job
-              metric_relabel_configs:
-                - source_labels: [__name__]
-                  regex: 'DCGM_FI_DEV_GPU_UTIL|DCGM_FI_DEV_MEM_COPY_UTIL'
-                  action: drop
                 # Convert DCGM percentage metrics to ratios (0-1 scale) for OCP compatibility
                 - source_labels: [__name__]
                   regex: 'nvidia_gpu_(utilization|memory_utilization)_ratio'
                   target_label: __tmp_scale_needed
                   replacement: 'true'
                 - source_labels: [__name__]
-                  regex: '(nvidia_gpu_temperature_celsius|nvidia_gpu_utilization_ratio|nvidia_gpu_memory_utilization_ratio|nvidia_gpu_memory_used_bytes|nvidia_gpu_memory_free_bytes|nvidia_gpu_power_usage_watts|nvidia_gpu_sm_clock_mhz|nvidia_gpu_memory_clock_mhz|DCGM_FI_DEV_GPU_TEMP|DCGM_FI_DEV_FB_USED|DCGM_FI_DEV_FB_FREE|DCGM_FI_DEV_POWER_USAGE|DCGM_FI_DEV_SM_CLOCK|DCGM_FI_DEV_MEM_CLOCK)'
+                  regex: '(nvidia_gpu_temperature_celsius|nvidia_gpu_utilization_ratio|nvidia_gpu_memory_utilization_ratio|nvidia_gpu_memory_used_bytes|nvidia_gpu_memory_free_bytes|nvidia_gpu_power_usage_watts|nvidia_gpu_sm_clock_mhz|nvidia_gpu_memory_clock_mhz)'
                   action: keep
               scrape_interval: 30s
               scrape_timeout: 10s


### PR DESCRIPTION
## Description

Port of opendatahub-io/opendatahub-operator#3997 to the module.

DCGM GPU metric rename rules using `__name__` were placed in `relabel_configs` (pre-scrape target-discovery stage) where `__name__` does not exist. The renames never fired, and `metric_relabel_configs` then unconditionally dropped `DCGM_FI_DEV_GPU_UTIL` and `DCGM_FI_DEV_MEM_COPY_UTIL`, leaving GPU utilization permanently empty on the AI Observability Dashboard.

Changes:
- Move all 8 DCGM rename rules from `relabel_configs` into `metric_relabel_configs` (post-scrape stage)
- Remove the now-dead drop rule for `DCGM_FI_DEV_GPU_UTIL|DCGM_FI_DEV_MEM_COPY_UTIL`
- Clean stale `DCGM_FI_*` alternatives from the keep regex
- Add unit test validating rule placement

## How Has This Been Tested?

```bash
go test ./internal/controller/ -run TestDCGMRenameRulesInMetricRelabelConfigs -v
```

New unit test validates that all 8 DCGM rename rules are in `metric_relabel_configs` (not `relabel_configs`) and that `relabel_configs` does not reference `__name__`.

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected accelerator metric relabeling so component and job labels are applied consistently.
  * Updated metric filtering to retain only the expected renamed NVIDIA GPU metrics.
  * Removed obsolete filtering for raw DCGM metric names.
* **Tests**
  * Added coverage verifying metric renaming and relabeling are placed in the correct configuration sections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->