### PR TITLE
fix(helm): add tempo.grafana.com trace-write RBAC for collector

### DIFF
--- a/charts/odh-observability/templates/rbac.yaml
+++ b/charts/odh-observability/templates/rbac.yaml
@@ -31,6 +31,11 @@ rules:
   - apiGroups: ["tempo.grafana.com"]
     resources: ["tempomonolithics", "tempostacks"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # Tempo trace-write (operator must hold this to grant it via collector-tempo-rbac ClusterRole)
+  - apiGroups: ["tempo.grafana.com"]
+    resources: ["{{ .Values.operatorNamespace }}"]
+    resourceNames: ["traces"]
+    verbs: ["create"]
   # OpenTelemetry
   - apiGroups: ["opentelemetry.io"]
     resources: ["opentelemetrycollectors", "instrumentations"]


### PR DESCRIPTION
## Description

The operator's Helm chart ClusterRole was missing the `tempo.grafana.com/<namespace>` permission needed to create the `data-science-collector-tempo-trace-export` ClusterRole at runtime. Kubernetes RBAC escalation prevention blocks a service account from granting permissions it doesn't hold itself, so enabling traces on the Monitoring CR caused a reconciliation error:

```
clusterroles.rbac.authorization.k8s.io "data-science-collector-tempo-trace-export" is forbidden:
user "system:serviceaccount:opendatahub:odh-observability" is attempting to grant RBAC permissions
not currently held: {APIGroups:["tempo.grafana.com"], Resources:["opendatahub"], ResourceNames:["traces"], Verbs:["create"]}
```

This adds the matching permission to the operator's ClusterRole so it can delegate trace-write access to the collector service account.

Also lowers the default e2e test timeout from 5 minutes to 2 minutes per assertion to surface failures faster.

## How Has This Been Tested?

- Deployed operator to OpenShift cluster with the fix
- Created Monitoring CR with traces enabled, verified CR reaches `Ready` phase and `data-science-collector-tempo-trace-export` ClusterRole is created (previously failed with RBAC escalation error)
- Ran full containerized e2e test suite: 96 tests, 0 failures, 1 skipped (~10 minutes)

## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled the operator to create observability traces in the configured namespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->