### PR TITLE
Update maas usage otel collector and lokistack for updated acces logs

### DIFF
--- a/internal/controller/resources/loki-stack.tmpl.yaml
+++ b/internal/controller/resources/loki-stack.tmpl.yaml
@@ -8,6 +8,10 @@ spec:
     global:
       queries:
         queryTimeout: 3m
+      otlp:
+        streamLabels:
+          resourceAttributes:
+            - name: service.name
     tenants:
       application:
         otlp:

--- a/internal/controller/resources/loki-stack.tmpl.yaml
+++ b/internal/controller/resources/loki-stack.tmpl.yaml
@@ -21,6 +21,10 @@ spec:
             - name: model
             - name: subscription
             - name: response_type
+            - name: gateway_namespace_name
+            - name: gateway_deployment_name
+            - name: upstream_namespace_name
+            - name: upstream_deployment_name
   managementState: Managed
   size: 1x.extra-small
   storage:
@@ -34,3 +38,5 @@ spec:
   storageClassName: {{.LokiStorageClassName}}
   tenants:
     mode: openshift-logging
+    openshift:
+      userFieldName: user_id

--- a/internal/controller/resources/usage-logs-opentelemetry-collector.tmpl.yaml
+++ b/internal/controller/resources/usage-logs-opentelemetry-collector.tmpl.yaml
@@ -30,8 +30,23 @@ spec:
             endpoint: '0.0.0.0:4318'
 
     processors:
-      batch: {}
+      # 1. Protect pod against OOM kills under heavy log spikes
+      memory_limiter:
+        check_interval: 1s
+        limit_mib: 200
+        spike_limit_mib: 50
 
+      # 2. Add resource attributes
+      resource:
+        attributes:
+          - action: upsert
+            key: log_type
+            value: application
+          - action: upsert
+            key: kubernetes_namespace_name
+            from_attribute: service.namespace
+
+      # 3. Enrich logs with Kubernetes pod/node/deployment metadata
       k8sattributes:
         auth_type: "serviceAccount"
         passthrough: false
@@ -46,24 +61,26 @@ spec:
           - sources:
             - from: resource_attribute
               name: k8s.pod.name
-          - sources:
             - from: resource_attribute
               name: k8s.namespace.name
 
-      resource:
-        attributes:
-          - action: upsert
-            key: log_type
-            value: application
-          - action: upsert
-            key: kubernetes_namespace_name
-            value: {{.GatewayNamespace}}
+      # 4. Generically strip leading/trailing quotes from ALL attribute values
+      transform:
+        error_mode: ignore
+        log_statements:
+          - context: log
+            statements:
+              - replace_all_patterns(attributes, "value", "^\"|\"$", "")
 
+      # 5. Group logs by core attributes
       groupbyattrs/maas:
         keys:
           - model
           - subscription
           - response_type
+
+      # 6. Batch logs for optimal export performance
+      batch: {}
 
     exporters:
 {{- if .UsageLogs}}
@@ -91,7 +108,7 @@ spec:
       pipelines:
         logs:
           receivers: [otlp]
-          processors: [resource, k8sattributes, groupbyattrs/maas, batch]
+          processors: [memory_limiter, resource, k8sattributes, transform, groupbyattrs/maas, batch]
           exporters:
 {{- if .UsageLogs}}
             - otlphttp/loki

--- a/internal/controller/resources/usage-logs-opentelemetry-collector.tmpl.yaml
+++ b/internal/controller/resources/usage-logs-opentelemetry-collector.tmpl.yaml
@@ -46,7 +46,17 @@ spec:
             key: kubernetes_namespace_name
             from_attribute: service.namespace
 
-      # 3. Enrich logs with Kubernetes pod/node/deployment metadata
+      # 3. Generically strip leading/trailing quotes from ALL attribute values
+      # also sets the k8s pod ip resource attribute tobe accessed later and provide addional k8s context to the log - whilst not being whiltelsited strema label in loki
+      transform:
+        error_mode: ignore
+        log_statements:
+          - context: log
+            statements:
+              - set(resource.attributes["k8s.pod.ip"], Split(attributes["upstream_host"], ":")[0]) where attributes["upstream_host"] != nil
+              - replace_all_patterns(attributes, "value", "^\"|\"$", "")
+
+      # 4. Enrich logs with Kubernetes pod/node/deployment metadata
       k8sattributes:
         auth_type: "serviceAccount"
         passthrough: false
@@ -60,17 +70,8 @@ spec:
         pod_association:
           - sources:
             - from: resource_attribute
-              name: k8s.pod.name
-            - from: resource_attribute
-              name: k8s.namespace.name
+              name: k8s.pod.ip
 
-      # 4. Generically strip leading/trailing quotes from ALL attribute values
-      transform:
-        error_mode: ignore
-        log_statements:
-          - context: log
-            statements:
-              - replace_all_patterns(attributes, "value", "^\"|\"$", "")
 
       # 5. Group logs by core attributes
       groupbyattrs/maas:
@@ -108,7 +109,7 @@ spec:
       pipelines:
         logs:
           receivers: [otlp]
-          processors: [memory_limiter, resource, k8sattributes, transform, groupbyattrs/maas, batch]
+          processors: [memory_limiter, resource, transform, k8sattributes, groupbyattrs/maas, batch]
           exporters:
 {{- if .UsageLogs}}
             - otlphttp/loki

--- a/internal/controller/resources/usage-logs-opentelemetry-collector.tmpl.yaml
+++ b/internal/controller/resources/usage-logs-opentelemetry-collector.tmpl.yaml
@@ -48,7 +48,12 @@ spec:
           - action: upsert
             key: kubernetes_namespace_name
             # from_attribute: service.namespace
-            value: opendatahub
+            value: {{.GatewayNamespace}}
+
+      # separate resource logs blocks so no overrides of the shared block upstream host value for k8s attributes correct information
+      groupbyattrs/upstream_host:
+        keys:
+          - upstream_host
 
       # 3. Generically strip leading/trailing quotes from ALL attribute values
       # also sets the k8s upstream pod ip resource attribute to be accessed later and provide addional k8s context to the log - whilst not being whiltelsited strema label in loki
@@ -57,7 +62,16 @@ spec:
         log_statements:
           - context: log
             statements:
-              - set(resource.attributes["k8s.pod.ip"], Split(attributes["upstream_host"], ":")[0]) where attributes["upstream_host"] != nil
+              # 1. Copy raw upstream_host to target resource attribute
+              - set(resource.attributes["k8s.pod.ip"], resource.attributes["upstream_host"]) where resource.attributes["upstream_host"] != nil
+
+              # 2a. For IPv6 ([addr]:port): strip brackets and port from k8s.pod.ip
+              - replace_pattern(resource.attributes["k8s.pod.ip"], "^\\[([^\\]]+)\\].*$", "$1") where resource.attributes["upstream_host"] != nil and IsMatch(resource.attributes["upstream_host"], "^\\[")
+
+              # 2b. For IPv4 (addr:port): extract clean IP before trailing port
+              - set(resource.attributes["k8s.pod.ip"], Split(resource.attributes["upstream_host"], ":")[0]) where resource.attributes["upstream_host"] != nil and IsMatch(resource.attributes["upstream_host"], "^\\[") == false
+
+              # 3. Clean quotes from all log attributes
               - replace_all_patterns(attributes, "value", "^\"|\"$", "")
 
       # 4. Enrich logs with Kubernetes pod/node/deployment Gateway metadata - if no gateway then will be general connection means wont require upstrea_host info as well
@@ -136,13 +150,13 @@ spec:
         log_statements:
           - context: log
             statements:
-              - delete_key(attributes, "upstream_host")
+              - delete_key(resource.attributes, "upstream_host")
               - delete_key(resource.attributes, "k8s.pod.ip")
               - delete_key(resource.attributes, "log_name")
               - delete_key(resource.attributes, "service.namespace")
               # envoy specific replaced by gateway k8sattributes
-              - delete_key(attributes, "cluster_name") 
-              - delete_key(attributes, "node_name")
+              - delete_key(resource.attributes, "cluster_name") 
+              - delete_key(resource.attributes, "node_name")
 
       # 7. Batch logs for optimal export performance
       batch: {}
@@ -173,7 +187,7 @@ spec:
       pipelines:
         logs:
           receivers: [otlp]
-          processors: [memory_limiter, resource, transform, k8sattributes, transform/gateway_k8sattributes, k8sattributes/upstream_pod, transform/upstream_pod_k8sattributes, transform/cleanup, groupbyattrs/maas, batch]
+          processors: [memory_limiter, resource, groupbyattrs/upstream_host, transform, k8sattributes, transform/gateway_k8sattributes, k8sattributes/upstream_pod, transform/upstream_pod_k8sattributes, transform/cleanup, groupbyattrs/maas, batch]
           exporters:
 {{- if .UsageLogs}}
             - otlphttp/loki

--- a/internal/controller/resources/usage-logs-opentelemetry-collector.tmpl.yaml
+++ b/internal/controller/resources/usage-logs-opentelemetry-collector.tmpl.yaml
@@ -36,18 +36,21 @@ spec:
         limit_mib: 200
         spike_limit_mib: 50
 
-      # 2. Add resource attributes
+      # 2. manage loki and loki-openshift known stream labels
+      # - log type if exists from source keep as is and if not get from resource attribute log_name (used by envoy access logger)
+      # - maas envoy filter uses service.namespace to provide the ai tenant namespace which is the one used for rbac in lokistack openshift-logging via the kubernetes_namespace_name - again update if not sent - allowing standard service.namespace naming from components 
+      # (possbily a mistake to allow service.namespace becuase of k8s services naming and otel spec but this is what maas has right now along service.name as well)
       resource:
         attributes:
           - action: upsert
             key: log_type
-            value: application
+            from_attribute: log_name
           - action: upsert
             key: kubernetes_namespace_name
             from_attribute: service.namespace
 
       # 3. Generically strip leading/trailing quotes from ALL attribute values
-      # also sets the k8s pod ip resource attribute tobe accessed later and provide addional k8s context to the log - whilst not being whiltelsited strema label in loki
+      # also sets the k8s upstream pod ip resource attribute to be accessed later and provide addional k8s context to the log - whilst not being whiltelsited strema label in loki
       transform:
         error_mode: ignore
         log_statements:
@@ -56,7 +59,7 @@ spec:
               - set(resource.attributes["k8s.pod.ip"], Split(attributes["upstream_host"], ":")[0]) where attributes["upstream_host"] != nil
               - replace_all_patterns(attributes, "value", "^\"|\"$", "")
 
-      # 4. Enrich logs with Kubernetes pod/node/deployment metadata
+      # 4. Enrich logs with Kubernetes pod/node/deployment Gateway metadata - if no gateway then will be general connection means wont require upstrea_host info as well
       k8sattributes:
         auth_type: "serviceAccount"
         passthrough: false
@@ -64,7 +67,37 @@ spec:
           metadata:
             - k8s.namespace.name
             - k8s.pod.name
-            - k8s.pod.uid
+            - k8s.deployment.name
+            - k8s.node.name
+        pod_association:
+          - sources: 
+            - from: connection
+
+      # 4. map gateway k8sattributes metadata to attributes with gateway_ prefix in field names - some possibly indexed and others not intended to be from otel.
+      # usually as this is the log creator this would remain otel native naming of k8s attributes but becuase loki with openshift-logging mode uses the k8s_namespace_name and its intended to be for rbac we cannot base access to logs on access to gateway namespace.
+      # also doesnt work for maas tenancy model.
+      transform/gateway_k8sattributes:
+        error_mode: ignore
+        log_statements:
+          - context: log
+            statements:
+              - set(resource.attributes["gateway_namespace_name"], resource.attributes["k8s.namespace.name"]) where resource.attributes["k8s.namespace.name"] != nil
+              - set(resource.attributes["gateway_deployment_name"], resource.attributes["k8s.deployment.name"]) where resource.attributes["k8s.deployment.name"] != nil
+              - set(attributes["gateway_pod_name"], resource.attributes["k8s.pod.name"]) where resource.attributes["k8s.pod.name"] != nil
+              - set(attributes["gateway_node_name"], resource.attributes["k8s.node.name"]) where resource.attributes["k8s.node.name"] != nil
+              - delete_key(resource.attributes, "k8s.namespace.name")
+              - delete_key(resource.attributes, "k8s.deployment.name")
+              - delete_key(resource.attributes, "k8s.pod.name")
+              - delete_key(resource.attributes, "k8s.node.name")
+
+      # 4. Enrich logs with Kubernetes pod/node/deployment upstream pod metadata - if doesnt exist then wont do anything
+      k8sattributes/upstream_pod:
+        auth_type: "serviceAccount"
+        passthrough: false
+        extract:
+          metadata:
+            - k8s.namespace.name
+            - k8s.pod.name
             - k8s.deployment.name
             - k8s.node.name
         pod_association:
@@ -72,15 +105,45 @@ spec:
             - from: resource_attribute
               name: k8s.pod.ip
 
+      # 4. map upstream pod k8sattributes metadata to attributes with upstream_ prefix in field names - some possibly indexed and others not intended to be from otel.
+      transform/upstream_pod_k8sattributes:
+        error_mode: ignore
+        log_statements:
+          - context: log
+            statements:
+              # Move k8s.namespace.name -> llm_namespace_name
+              - set(resource.attributes["upstream_namespace_name"], resource.attributes["k8s.namespace.name"]) where resource.attributes["k8s.namespace.name"] != nil
+              - set(resource.attributes["upstream_deployment_name"], resource.attributes["k8s.deployment.name"]) where resource.attributes["k8s.deployment.name"] != nil
+              - set(attributes["upstream_pod_name"], resource.attributes["k8s.pod.name"]) where resource.attributes["k8s.pod.name"] != nil
+              - set(attributes["upstream_node_name"], resource.attributes["k8s.node.name"]) where resource.attributes["k8s.node.name"] != nil
+              - delete_key(resource.attributes, "k8s.namespace.name")
+              - delete_key(resource.attributes, "k8s.deployment.name")
+              - delete_key(resource.attributes, "k8s.pod.name")
+              - delete_key(resource.attributes, "k8s.node.name")
 
-      # 5. Group logs by core attributes
+      # 5. Group logs by core attributes - puts them at resource attributes level instead of log attributes
+      # Meaning if whitelisted in loki they will be stream labels instead of structured metadata - meaning indexed
       groupbyattrs/maas:
         keys:
           - model
           - subscription
           - response_type
 
-      # 6. Batch logs for optimal export performance
+      # 6. Clean up temporary and redundant fields before export
+      transform/cleanup:
+        error_mode: ignore
+        log_statements:
+          - context: log
+            statements:
+              - delete_key(attributes, "upstream_host")
+              - delete_key(resource.attributes, "k8s.pod.ip")
+              - delete_key(resource.attributes, "log_name")
+              - delete_key(resource.attributes, "service.namespace")
+              # envoy specific replaced by gateway k8sattributes
+              - delete_key(attributes, "cluster_name") 
+              - delete_key(attributes, "node_name")
+
+      # 7. Batch logs for optimal export performance
       batch: {}
 
     exporters:
@@ -109,7 +172,7 @@ spec:
       pipelines:
         logs:
           receivers: [otlp]
-          processors: [memory_limiter, resource, transform, k8sattributes, groupbyattrs/maas, batch]
+          processors: [memory_limiter, resource, transform, k8sattributes, transform/gateway_k8sattributes, k8sattributes/upstream_pod, transform/upstream_pod_k8sattributes, transform/cleanup, groupbyattrs/maas, batch]
           exporters:
 {{- if .UsageLogs}}
             - otlphttp/loki

--- a/internal/controller/resources/usage-logs-opentelemetry-collector.tmpl.yaml
+++ b/internal/controller/resources/usage-logs-opentelemetry-collector.tmpl.yaml
@@ -47,7 +47,8 @@ spec:
             from_attribute: log_name
           - action: upsert
             key: kubernetes_namespace_name
-            from_attribute: service.namespace
+            # from_attribute: service.namespace
+            value: opendatahub
 
       # 3. Generically strip leading/trailing quotes from ALL attribute values
       # also sets the k8s upstream pod ip resource attribute to be accessed later and provide addional k8s context to the log - whilst not being whiltelsited strema label in loki


### PR DESCRIPTION
## Description
Implemented some of desired stuff from https://redhat.atlassian.net/browse/RHOAIENG-83720

Before PR maas access logs:

<img width="2340" height="1284" alt="Screenshot 2026-08-27 at 19 17 42" src="https://github.com/user-attachments/assets/d682accb-dd84-4e30-bbc0-20eec45cc11c" />

task assigned to add trace_id, k8s.pod.name (and extra k8s attributes), service.name (in the current logging case models-as-a-service), severity.
this along with a custom maas tenant for separate retention control and more.

separate maas tenant in loki will not happen in this release (maas and maas loki access logs multi tenancy are a separate future issue currently being discused in https://docs.google.com/document/d/1bT3vi3WipQK1HDYUNHrbRn7fe-IAXFnU9u1mE2BVwK8/edit?usp=sharing)

trace_id possibly not for 3.6ea1 after all? @chambridge
if so we need maas to send it with envoy filter.

severity relavnt for pure component logs not access logs that include response type as an indexed field (already did before this pr)

What was added?

addition of the service name indexed field (already sent by maas gateways), needed to be acknoledged as a sdesired indexed stream label field in loki.

addition of log_type correct field (before was the loki tenant when it didnt need to be whislt also recieving a log_name from envoy as a resource attribute allowed to be dual log_type and name indexed fields (loki acknoledges only log_type by default, eenvoy only sends log_name as standard). needed to reword log_name to log_type and now its indexed with the value from maas (maas-usage-logs)

addition of k8s attributes. this is tricky becuase k8s attributes by the otel standard are k8s.<>
then if we have access logs the standard is that the log creator gets the k8s.<> and the upstream handler of the requets (in teh case of maas vllmd) get like a custom name.
but wiht loki via lokistack in openshif tlogging mode the k8s.namespace.name and kubernets_namepsace_name are reservered to do access control by with SAR and we wouldnt want the role bindings on log reosurces and loki tenants to be given in namepsaces of the gateways (currently mostly deployed in opensifhit-ingress namesapce regardless of the llm nsmaspace).
So decided to set gateway k8s attributes with gateway_<> naming and upstream llm with upstream_<> naming e.g. gateway_namespace_name and gateway_deployment_name  and same fro upstream_namespace_name etc...
listed k8s resources for each are namespace, deployment, pod and node names.

for upstream information i needed to add handling of field expected by producers (in maas case the envoy access log filter) of field upstream_host, so this is also inlcuded here. Again it expects the upstream_host to be sent from the producer to be used by otel to gather k8s attributes on it. if not sent no error will happen just will be missing the upstream vllmd j8s attributes (in the maas case).
Any log prouducer that goes trough this otel will have its k8s information gathered without needing to send anything.
this solution is only needed for components with proxies.

pr for maas to add upstream_host field in envoy filter needs to be created.

lastly kubernetes_namespace_name is curretnly hardset to opendatahub. this pr changes that to set it to maas sent service.namespace field. The reason being that filed is supposed to be the ai tenant field menaning the loki logs accesss cotnrol accross its loki tenants will be k8s sar checked on one to one maas ai ternant namespaces.
The only downside of this chnage now is that the pr for maas to update the field to be the ai tenant namespace instead of static openshift-ingress is still awaiting merge (its open an hopefully will be merged by code freeze).

also removed the cluster_name and node_name fiedls specific to envoy (not k8s cluster and node) just becuase irrelvant now that k8s native otel gathers on gateway and upstream)

with changes:

<img width="1044" height="496" alt="image" src="https://github.com/user-attachments/assets/dde5b87e-b57d-45cf-8d1a-58f7840fa1f7" />
<img width="1044" height="360" alt="image" src="https://github.com/user-attachments/assets/e9bdab28-b47f-4ad1-87a3-6431ce22ba0e" />


## How Has This Been Tested?
ran simulated vllmd and maas with envoy filter on the gateway and the odh observability modules deployed along odh operator with monitoring removed. checked all cases of envoy filter with upstream host adn without to see no errors from ours side of the config and was good along with all the other additions.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved application log labels with service, gateway, upstream, and tenant metadata.
  - Added richer Kubernetes context to usage logs, including pod, deployment, node, and namespace details.
  - Enhanced log processing to derive pod information, group related logs, and normalize attribute values.
  - Added clearer tenant identification and service-related stream labels.

- **Bug Fixes**
  - Added memory protection to reduce the risk of collector out-of-memory failures.
  - Improved log metadata consistency and removed temporary processing fields before export.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->