### PR TITLE
fix(helm): grant Tempo trace-write on monitoring namespace

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,13 +181,15 @@ image: docker-build docker-push ## Build and push image with the manager.
 
 HELM_RELEASE ?= odh-observability
 HELM_CHART   ?= charts/odh-observability
-NAMESPACE    ?= opendatahub
+NAMESPACE              ?= opendatahub
+MONITORING_NAMESPACE   ?= $(NAMESPACE)
 
 .PHONY: deploy
 deploy: manifests helm-update-crds ## Deploy operator to cluster via Helm chart.
 	helm upgrade --install $(HELM_RELEASE) $(HELM_CHART) \
 		-n $(NAMESPACE) --create-namespace \
 		--set operatorNamespace=$(NAMESPACE) \
+		--set monitoringNamespace=$(MONITORING_NAMESPACE) \
 		--set image.repository=$(firstword $(subst :, ,$(IMG))) \
 		--set image.tag=$(lastword $(subst :, ,$(IMG)))
 

--- a/charts/odh-observability/README.md
+++ b/charts/odh-observability/README.md
@@ -37,6 +37,7 @@ helm uninstall odh-observability --namespace odh-observability-system
 | `nameOverride` | string | `""` | Override the chart name |
 | `fullnameOverride` | string | `""` | Override the fully qualified app name |
 | `operatorNamespace` | string | `"opendatahub-operator-system"` | Namespace for all operator resources |
+| `monitoringNamespace` | string | `""` | Namespace where Monitoring operands (Tempo, collector) are deployed. Defaults to `operatorNamespace` when empty. On RHOAI this is DSCI `spec.monitoring.namespace`. |
 | `image.repository` | string | `"quay.io/opendatahub/odh-observability"` | Controller container image repository |
 | `image.tag` | string | `"odh-stable"` | Controller container image tag |
 | `image.pullPolicy` | string | `"Always"` | Image pull policy |

--- a/charts/odh-observability/templates/_helpers.tpl
+++ b/charts/odh-observability/templates/_helpers.tpl
@@ -47,3 +47,12 @@ Chart label
 {{- define "odh-observability.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
 {{- end }}
+
+{{/*
+Namespace where Monitoring operands (Tempo, collector) are deployed.
+Tempo write ACL treats this namespace name as the RBAC resource.
+Falls back to operatorNamespace when monitoringNamespace is unset.
+*/}}
+{{- define "odh-observability.monitoringNamespace" -}}
+{{- default .Values.operatorNamespace .Values.monitoringNamespace }}
+{{- end }}

--- a/charts/odh-observability/templates/rbac.yaml
+++ b/charts/odh-observability/templates/rbac.yaml
@@ -31,9 +31,11 @@ rules:
   - apiGroups: ["tempo.grafana.com"]
     resources: ["tempomonolithics", "tempostacks"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-  # Tempo trace-write (operator must hold this to grant it via collector-tempo-rbac ClusterRole)
+  # Tempo trace-write (operator must hold this to grant it via collector-tempo-rbac ClusterRole).
+  # Tempo's write ACL uses the monitoring namespace name as the RBAC resource, which
+  # differs from operatorNamespace on RHOAI (applications vs monitoring namespaces).
   - apiGroups: ["tempo.grafana.com"]
-    resources: ["{{ .Values.operatorNamespace }}"]
+    resources: ["{{ include "odh-observability.monitoringNamespace" . }}"]
     resourceNames: ["traces"]
     verbs: ["create"]
   # OpenTelemetry

--- a/charts/odh-observability/values.schema.json
+++ b/charts/odh-observability/values.schema.json
@@ -14,6 +14,10 @@
       "type": "string",
       "description": "Namespace for all operator resources"
     },
+    "monitoringNamespace": {
+      "type": "string",
+      "description": "Namespace where Monitoring operands are deployed. Defaults to operatorNamespace when empty."
+    },
     "image": {
       "type": "object",
       "properties": {

--- a/charts/odh-observability/values.yaml
+++ b/charts/odh-observability/values.yaml
@@ -3,6 +3,12 @@ fullnameOverride: ""
 
 operatorNamespace: opendatahub-operator-system
 
+# Namespace where Monitoring operands (Tempo, collector) are deployed.
+# Tempo write ACL treats this namespace name as the RBAC resource.
+# Defaults to operatorNamespace when empty. On RHOAI this is
+# spec.monitoring.namespace (e.g. redhat-ods-monitoring).
+monitoringNamespace: ""
+
 image:
   repository: quay.io/opendatahub/odh-observability
   tag: odh-stable


### PR DESCRIPTION
## Description

Tempo write ACL treats the **namespace name** as the RBAC `resource`. The manager ClusterRole must hold that permission in order to grant `data-science-collector-tempo-trace-export`.

The chart currently templates that rule with `operatorNamespace` (the applications namespace). That works on ODH, where apps and monitoring share `opendatahub`. On RHOAI they differ (`redhat-ods-applications` vs `redhat-ods-monitoring`), so Kubernetes rejects the collector ClusterRole as an RBAC escalation and traces never deploy.

This adds a `monitoringNamespace` Helm value and uses it for the Tempo trace-write rule, falling back to `operatorNamespace` when unset.

The platform operator must pass DSCI `spec.monitoring.namespace` as this value. That is a follow-up in opendatahub-operator.

## How Has This Been Tested?

- `helm lint charts/odh-observability`
- `helm template` with default values: Tempo write `resources` is `opendatahub-operator-system` (fallback)
- `helm template --set operatorNamespace=redhat-ods-applications --set monitoringNamespace=redhat-ods-monitoring`: Tempo write `resources` is `redhat-ods-monitoring`

Not yet verified on a live RHOAI cluster. That needs this chart vendored plus the operator Helm-value change. The failure was reproduced on CaaS: collector stayed metrics-only with

```
clusterroles "data-science-collector-tempo-trace-export" is forbidden:
attempting to grant RBAC permissions not currently held:
{APIGroups:["tempo.grafana.com"], Resources:["redhat-ods-monitoring"], ResourceNames:["traces"], Verbs:["create"]}
```
Output locally:
```
cgoodfre@cgoodfre-mac odh-observability % helm template odh-observability charts/odh-observability \
  | grep -A6 'Tempo trace-write'
  # Tempo trace-write (operator must hold this to grant it via collector-tempo-rbac ClusterRole).
  # Tempo's write ACL uses the monitoring namespace name as the RBAC resource, which
  # differs from operatorNamespace on RHOAI (applications vs monitoring namespaces).
  - apiGroups: ["tempo.grafana.com"]
    resources: ["opendatahub-operator-system"]
    resourceNames: ["traces"]
    verbs: ["create"]
cgoodfre@cgoodfre-mac odh-observability % helm template odh-observability charts/odh-observability \
  --set operatorNamespace=redhat-ods-applications \
  --set monitoringNamespace=redhat-ods-monitoring \
  | grep -A6 'Tempo trace-write'
  # Tempo trace-write (operator must hold this to grant it via collector-tempo-rbac ClusterRole).
  # Tempo's write ACL uses the monitoring namespace name as the RBAC resource, which
  # differs from operatorNamespace on RHOAI (applications vs monitoring namespaces).
  - apiGroups: ["tempo.grafana.com"]
    resources: ["redhat-ods-monitoring"]
    resourceNames: ["traces"]
    verbs: ["create"]
```
## Merge criteria:

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable namespace placement for monitoring components.
  * Monitoring components now default to the operator namespace when no separate namespace is specified.
  * Deployment configuration passes the selected monitoring namespace through to Helm.

* **Bug Fixes**
  * Updated trace-writing permissions to work correctly when monitoring and operator components use different namespaces.

* **Documentation**
  * Documented the new monitoring namespace setting and its default behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->