### PR TITLE
[-] remove accidnetaly meregd user field spec in lokistack

### DIFF
--- a/internal/controller/resources/loki-stack.tmpl.yaml
+++ b/internal/controller/resources/loki-stack.tmpl.yaml
@@ -38,5 +38,3 @@ spec:
   storageClassName: {{.LokiStorageClassName}}
   tenants:
     mode: openshift-logging
-    openshift:
-      userFieldName: user_id


### PR DESCRIPTION
relevant for future lokistack release if accepted and merged by lokistakc and observatorium managers.

accirdently released from stash and merged.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the OpenShift tenant configuration to use the default user field behavior.
  * Removed the custom `user_id` field declaration from the LokiStack configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->