### PR TITLE
Usage envoy filter maas ai tenant based logs sar

### DIFF
--- a/internal/controller/resources/usage-logs-opentelemetry-collector.tmpl.yaml
+++ b/internal/controller/resources/usage-logs-opentelemetry-collector.tmpl.yaml
@@ -151,9 +151,9 @@ spec:
             statements:
               - delete_key(resource.attributes, "upstream_host")
               - delete_key(resource.attributes, "k8s.pod.ip")
-              - delete_key(resource.attributes, "log_name")
               - delete_key(resource.attributes, "service.namespace")
               # envoy specific replaced by gateway k8sattributes
+              - delete_key(resource.attributes, "log_name")
               - delete_key(resource.attributes, "cluster_name") 
               - delete_key(resource.attributes, "node_name")
 

--- a/internal/controller/resources/usage-logs-opentelemetry-collector.tmpl.yaml
+++ b/internal/controller/resources/usage-logs-opentelemetry-collector.tmpl.yaml
@@ -47,8 +47,7 @@ spec:
             from_attribute: log_name
           - action: upsert
             key: kubernetes_namespace_name
-            # from_attribute: service.namespace
-            value: {{.GatewayNamespace}}
+            from_attribute: service.namespace
 
       # separate resource logs blocks so no overrides of the shared block upstream host value for k8s attributes correct information
       groupbyattrs/upstream_host:


### PR DESCRIPTION
## Description
made the maas inference access log (one to one per request) origin namespace be the sent service namespace from maas newly changed to the ai tenant the model is from. this allows for ai tenant based sar for loki.

## How Has This Been Tested?

deployed full pipeline from odh ai gateway and observability stack and tested infernce reqeusts from ai tenants


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Usage logs now derive the Kubernetes namespace from service metadata, improving namespace accuracy.
  * Log metadata fields are populated more consistently when processing incoming records.
  * Cleanup processing now handles service namespace information before log name data, preserving the expected metadata handling order.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->