### PR TITLE
RHOAIENG-94406 - TempoStack cannot become ready due to low default me…

### DIFF
--- a/internal/controller/templatedata.go
+++ b/internal/controller/templatedata.go
@@ -68,7 +68,7 @@ const (
 	defaultCollectorMemoryRequest = "256Mi"
 
 	defaultTempoCPULimit      = "1"
-	defaultTempoMemoryLimit   = "256Mi"
+	defaultTempoMemoryLimit   = "1Gi"
 	defaultTempoCPURequest    = "100m"
 	defaultTempoMemoryRequest = "256Mi"
 


### PR DESCRIPTION
…mory limits

<!--- Provide a general summary of your changes in the Title above -->
**JIRA:** [RHOAIENG-94406](https://redhat.atlassian.net/browse/RHOAIENG-94406)
## Description
This was already verified in https://github.com/opendatahub-io/opendatahub-operator/pull/4088 which uses the same fix to allow TempoStack to deploy.

## How Has This Been Tested?
Already tested by the opendatahub-operator PR.

## Merge criteria:
<!--- This PR will be merged by any repository approver when it meets all the points in the checklist -->
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] The commits are squashed in a cohesive manner and have meaningful messages.
- [x] Testing instructions have been added in the PR body (for PRs involving changes that are not immediately obvious).
- [x] The developer has manually tested the changes and verified that the changes work


[RHOAIENG-94406]: https://redhat.atlassian.net/browse/RHOAIENG-94406?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Increased the default memory limit for Tempo to 1 GiB to support larger workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->